### PR TITLE
community-meetings/2021-06-08: agenda

### DIFF
--- a/community-meetings/2021-06-08.md
+++ b/community-meetings/2021-06-08.md
@@ -1,0 +1,34 @@
+# Agenda for the Flatcar community call on Tuesday, 8th of June, 17:30 CEST
+
+## Links for participants
+- Call (for actively participating): [https://zoom.us/j/91719071935](https://zoom.us/j/91719071935)
+- Youtube live stream link (for passively watching): will be published shortly before the call.
+
+## Welcome
+- Brief intro / check-in of all participants in the Zoom call. Please introduce yourself and share what brings you here today.
+- Review the meeting agenda.
+
+## Spotlight: Nebraska update server
+- Brief presentation of Flatcar’s open source update server.
+
+## Spotlight: Nightlies, Tests, and Releases
+- Brief presentation of Flatcar’s test and releases process.
+
+## Status update: ARM64
+- What’s done, what’s missing, and how to help.
+
+## Releases review & planning
+- We share details of the March 19th release, some bumps encountered.
+- We plan the next releases, including new features, bug fixes, and related PRs.
+
+## Q&A
+- Questions from community participants, answered by the Flatcar maintainers.
+
+
+# Call Minutes
+
+As usual, the meeting minutes will be added here after the call.
+
+## Q&A
+
+Q&A minutes go here.

--- a/community-meetings/2021-06-08.md
+++ b/community-meetings/2021-06-08.md
@@ -18,7 +18,7 @@
 - What’s done, what’s missing, and how to help.
 
 ## Releases review & planning
-- We share details of the March 19th release, some bumps encountered.
+- We share details of the May 19th release, some bumps encountered.
 - We plan the next releases, including new features, bug fixes, and related PRs.
 
 ## Q&A


### PR DESCRIPTION
Add the Agenda for our upcoming community call on Tuesday, 8th of June, 2021.