### PR TITLE
Update the correct Zoom meeting id

### DIFF
--- a/community-meetings/2021-07-13.md
+++ b/community-meetings/2021-07-13.md
@@ -1,7 +1,7 @@
 # Agenda for the Flatcar community call on Tuesday, 13th of July, 17:30 CEST
 
 ## Links for participants
-- Call (for actively participating): [https://zoom.us/j/91719071935](https://zoom.us/j/91719071935)
+- Call (for actively participating): [https://zoom.us/j/96904526330](https://zoom.us/j/96904526330)
 - Youtube live stream link (for passively watching): will be published shortly before the call.
 
 ## Welcome


### PR DESCRIPTION
Update the Zoom meeting id. The one present is incorrect one, and needs to be updated with the actual one.