### PR TITLE
community calls: add agenda for 2021-08-10 call

### DIFF
--- a/community-meetings/2021-08-10.md
+++ b/community-meetings/2021-08-10.md
@@ -13,7 +13,7 @@
 ## Spotlight: Docker 20.10 / cgroups v2 update
 - Docker 20 and CGroups v2 (unified mode) are coming to Flatcar Linux! We'll give an overview of the challenges and the implications, as well as discuss the timeline.
 
-## Spotlight community committer: fixing the Locksmith reboot issue
+## Spotlight community committer: contributing to Flatcar
 - What it took Aniruddha to contribute to Flatcar and solve the locksmith reboot issue.
 
 ## Status update: ARM64
@@ -24,4 +24,3 @@
 
 ## Q&A
 - Questions from community participants, answered by the Flatcar maintainers.
-

--- a/community-meetings/2021-08-10.md
+++ b/community-meetings/2021-08-10.md
@@ -1,0 +1,27 @@
+# Flatcar community call Tuesday, 10th of August, 5:30 pm CEST
+
+- Zoom link for active participation: [https://us06web.zoom.us/j/83689202160](https://us06web.zoom.us/j/83689202160)
+- Youtube stream for passively watching: [Link will become available shortly before the meeting]
+
+## Welcome
+- Brief intro / check-in of all participants in the Zoom call. Please introduce yourself and share what brings you here today.
+- Review the meeting agenda.
+
+## News
+- New section! We briefly discuss news and happenings in the Flatcar world.
+
+## Spotlight: Docker 20.10 / cgroups v2 update
+- Docker 20 and CGroups v2 (unified mode) are coming to Flatcar Linux! We'll give an overview of the challenges and the implications, as well as discuss the timeline.
+
+## Spotlight community committer: fixing the Locksmith reboot issue
+- What it took Aniruddha to contribute to Flatcar and solve the locksmith reboot issue.
+
+## Status update: ARM64
+- What’s done, what’s missing, and how to help.
+
+## Releases review & planning
+- We plan the next releases, including new features, bug fixes, and related PRs.
+
+## Q&A
+- Questions from community participants, answered by the Flatcar maintainers.
+


### PR DESCRIPTION
This PR adds the agenda for the upcoming August community call. The PR is currently in Draft mode, the following TODOs are open:
- [x] @t-lo to prepare "News" section
- [x] @join2ashish to add Zoom link (feel free to add the link in a comment to this PR)
- [ ] @jepio to prepare presentation on cgroups v2 / docker 20.10 Spotlight
- [ ] @aniruddha2000 to prepare presentation on Locksmith work (please let us know in the PR comments!)
- [ ] @miao0miao and @wrl to prepare ARM64 status update
- [x] @sayanchowdhury to prepare for release planning section