### PR TITLE
community calls: Add Release Planning call agenda for August 23rd, 2021

### DIFF
--- a/community-meetings/2021-08-23.md
+++ b/community-meetings/2021-08-23.md
@@ -1,0 +1,14 @@
+# Agenda for the Flatcar Release Planning call on Monday, August of 23rd, 17:30 CEST
+
+## Links for participants
+- Call (for actively participating): [https://us06web.zoom.us/j/85781192057](https://us06web.zoom.us/j/85781192057)
+- Youtube live stream link (for passively watching): [Link will become available shortly before the meeting]
+- Release Planning Board: [https://github.com/orgs/kinvolk/projects/15](https://github.com/orgs/kinvolk/projects/15)
+
+## Welcome
+- Brief introduction of new participants or attendees
+- Status of the previous Flatcar Release
+- Planning for the upcoming release for the week of August 30th.
+
+## Q&A
+- Questions from community participants, answered by the Flatcar maintainers.


### PR DESCRIPTION
This PR adds the agenda for the upcoming August Release Planning call. The PR is currently in Draft mode, and should be merged after the Zoom link for the meeting is updated.

@join2ashish Could you please create a Zoom Meeting invite for the next Release Planning call?