### PR TITLE
community-meetings: add agenda for 2021-09-14

### DIFF
--- a/community-meetings/2021-09-14.md
+++ b/community-meetings/2021-09-14.md
@@ -1,0 +1,22 @@
+# Flatcar community call Tuesday, 14th of September, 5:30 pm CEST
+
+- Zoom link (for active participation): ***[TODO: add link]***
+- Youtube live stream (for passively watching): *will be added briefly before the call starts*
+
+## Welcome
+- Brief intro / check-in of all participants in the Zoom call. Please introduce yourself and share what brings you here today.
+
+## News
+- We will discuss news and happenings in the Flatcar world, including our move out of the Kinvolk github org back into our own!
+
+## Spotlight: Equinix Metal's use of Flatcar Container Linux
+- Andy Holtzmann [@andy-v-h](https://github.com/andy-v-h) gives an introduction on EM's use of Flatcar.
+
+## Status update: ARM64
+- Progress made, remaining items, and next steps.
+
+## Releases review & planning (updated section!)
+- We'll wrap up changes for the upcoming release (week of September 20) and will plan items we aim to integrate for the release after that (week of October 4th).
+
+## Q&A
+- Questions from community participants, answered by the Flatcar maintainers.


### PR DESCRIPTION
Agenda for our community call on the 14th of September.

Open items before merge:
- [x] @andy-v-h to have a look
- [x] @join2ashish to add Zoom link 