### PR TITLE
community-meetings: Add the agenda for the 2021-09-28 meeting

### DIFF
--- a/community-meetings/2021-09-28.md
+++ b/community-meetings/2021-09-28.md
@@ -1,7 +1,7 @@
 # Agenda for the Flatcar Release Team call on Tuesday, September 28th, 5:30pm CEST / 9pm IST / 3:30pm GMT / 11:30am EDT / 8:30am PST
 
 ## Links for participants
-- Call (for actively participating): TBA
+- Call (for actively participating): https://us06web.zoom.us/j/82054240491
 - Youtube live stream link (for passively watching): To be announced 5 minutes before the meeting
 - Release Planning Board: [https://github.com/orgs/flatcar-linux/projects/5](https://github.com/orgs/flatcar-linux/projects/5)
 

--- a/community-meetings/2021-09-28.md
+++ b/community-meetings/2021-09-28.md
@@ -1,0 +1,15 @@
+# Agenda for the Flatcar Release Team call on Tuesday, September 28th, 5:30pm CEST / 9pm IST / 3:30pm GMT / 11:30am EDT / 8:30am PST
+
+## Links for participants
+- Call (for actively participating): TBA
+- Youtube live stream link (for passively watching): To be announced 5 minutes before the meeting
+- Release Planning Board: [https://github.com/orgs/flatcar-linux/projects/5](https://github.com/orgs/flatcar-linux/projects/5)
+
+## Welcome
+- Brief introduction of new participants or attendees
+- Status of the previous Flatcar Release
+- Status/Planning for the release for the week of October 4th
+- Planning for the release for the week of October 18th
+
+## Q&A
+- Questions from community participants, answered by the Flatcar maintainers.


### PR DESCRIPTION
Add the agenda for the next Release Team meeting. 

Blockers for merge:
- [ ] @t-lo Can you comment/add the Zoom meeting link?