### PR TITLE
community-meetings: add 2021-11-09 agenda

### DIFF
--- a/community-meetings/2021-11-09.md
+++ b/community-meetings/2021-11-09.md
@@ -1,0 +1,31 @@
+# Flatcar community call Tuesday, 9th of November, 5:30pm CEST / 9pm IST / 3:30pm GMT / 11:30am EDT / 8:30am PST
+
+- Zoom link: [https://us06web.zoom.us/j/84336116610](https://us06web.zoom.us/j/84336116610)
+  - Meeting ID: 843 3611 6610
+  - Passcode: 444888
+- Youtube live stream / recording: [https://www.youtube.com/watch?v=YP9HnYxepVo](https://www.youtube.com/watch?v=YP9HnYxepVo)
+
+- Community Calls calendar (all future calls): [link](https://calendar.google.com/calendar/u/0/embed?src=c_ii991mqrpta9en8o7ofd4v19g4@group.calendar.google.com)
+  - iCal version: [link](https://calendar.google.com/calendar/ical/c_ii991mqrpta9en8o7ofd4v19g4%40group.calendar.google.com/public/basic.ics)
+
+## Welcome
+- Brief intro / check-in of all participants in the Zoom call. Please introduce yourself and share what brings you here today.
+
+## News
+- We will discuss news and happenings in the Flatcar world.
+  - CGroups V2 are coming to stable
+  - ARM64 goes beta
+
+## Spotlight: Flatcar dev mini-projects
+- Flatcar on Firecracker hack + demo
+- [Open Slot - your dev project here!]
+
+## Status update: ARM64
+- Progress made, next steps, and path to stable.
+
+## Release planning
+- Status/Planning for the release for the week of November 15th
+- Planning for the release for the week of November 29th
+
+## Q&A
+- Questions from community participants, answered by the Flatcar maintainers - e.g. feedback on the new Stable release w/ cgroups v2.

--- a/community-meetings/2021-11-09.md
+++ b/community-meetings/2021-11-09.md
@@ -3,7 +3,7 @@
 - Zoom link: [https://us06web.zoom.us/j/84336116610](https://us06web.zoom.us/j/84336116610)
   - Meeting ID: 843 3611 6610
   - Passcode: 444888
-- Youtube live stream / recording: [https://www.youtube.com/watch?v=YP9HnYxepVo](https://www.youtube.com/watch?v=YP9HnYxepVo)
+- Youtube live stream / recording: to be announced 5 minutes before
 
 - Community Calls calendar (all future calls): [link](https://calendar.google.com/calendar/u/0/embed?src=c_ii991mqrpta9en8o7ofd4v19g4@group.calendar.google.com)
   - iCal version: [link](https://calendar.google.com/calendar/ical/c_ii991mqrpta9en8o7ofd4v19g4%40group.calendar.google.com/public/basic.ics)

--- a/community-meetings/2021-11-09.md
+++ b/community-meetings/2021-11-09.md
@@ -17,8 +17,9 @@
   - ARM64 goes beta
 
 ## Spotlight: Flatcar dev mini-projects
+- OpenSSL 3.0 in Alpha-3046.0.0 FIPS provider showcase
+- ignition-as-a-service: online ignition transpiler
 - Flatcar on Firecracker hack + demo
-- [Open Slot - your dev project here!]
 
 ## Status update: ARM64
 - Progress made, next steps, and path to stable.


### PR DESCRIPTION
Add agenda for 2021-11-09 community meeting. There's some space / free slots available in the "Flatcar dev projects" section; please comment / ping us if you like to show something or even run a demo!