### PR TITLE
Stop using flatcar-linux redirects

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,6 +1,6 @@
 # Maintainers
 
-See [Governance](https://github.com/flatcar-linux/Flatcar/blob/main/governance.md) for governance, commit, and vote guidelines as well as maintainer responsibilities. Everybody listed in this file is a committer as per governance definition.
+See [Governance](https://github.com/flatcar/Flatcar/blob/main/governance.md) for governance, commit, and vote guidelines as well as maintainer responsibilities. Everybody listed in this file is a committer as per governance definition.
 
 
 ## Repositories

--- a/adding-new-packages.md
+++ b/adding-new-packages.md
@@ -23,4 +23,4 @@ Other criteria that are weighed are the following.
 
 ## How to propose a package for inclusion
 
-In order to propose a new package for inclusion, [open an issue using the "New Package Request" template](https://github.com/flatcar-linux/Flatcar/issues/new?assignees=&labels=kind%2Fnew-package&template=new-package-request.md&title=New+Package+Request%3A+%5Bpackage-name%5D).
+In order to propose a new package for inclusion, [open an issue using the "New Package Request" template](https://github.com/flatcar/Flatcar/issues/new?assignees=&labels=kind%2Fnew-package&template=new-package-request.md&title=New+Package+Request%3A+%5Bpackage-name%5D).


### PR DESCRIPTION
This changes two links to use github.com/flatcar instead of github.com/flatcar-linux.
