### PR TITLE
Create SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -10,5 +10,5 @@ Every day look into upstream security trackers like below:
 - Golang announce mailing list
 - Rust security announcements
 - (optional) RedHat vulnerabilities
-- If we see any new CVE, then add it to the CVE spreadsheets (still private), and click the link (above left) to generate new issues. Then we should be able to see a new issue created in Kinvolk security Github issues. (still private)
+- Whenever we discover any new CVE, we add it to an internal database, and use automation tools to create a new issue about the CVE in [Flatcar GitHub issues](https://github.com/Flatcar/Flatcar/issues) with labels `security` and `advisory`.
 - If the package of the new CVE is already open in Kinvolk security Github issues, then unfortunately we need to manually edit the existing issue to add the new CVE.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -11,4 +11,4 @@ Every day look into upstream security trackers like below:
 - Rust security announcements
 - (optional) RedHat vulnerabilities
 - Whenever we discover any new CVE, we add it to an internal database, and use automation tools to create a new issue about the CVE in [Flatcar GitHub issues](https://github.com/Flatcar/Flatcar/issues) with labels `security` and `advisory`.
-- If the package of the new CVE is already open in Kinvolk security Github issues, then unfortunately we need to manually edit the existing issue to add the new CVE.
+- If an issue of updating the specific package affected by the new CVE is already open in [Flatcar GitHub issues](https://github.com/Flatcar/Flatcar/issues), then unfortunately we need to manually edit the existing issue to add the new CVE.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,6 +1,17 @@
 # Flatcar Security 
-<todo - describe a security Schedule of tracking security issues of Flatcar>
-- Describe the process of tracking security issues for Flatcar, especially tracking issues from upstream projects like Gentoo Linux.
+To keep Flatcar secure, the maintainers put a strong focus on tracking new and existing security issues.
+Dealing with Security concerns is owned by the [Flatcar Security team](https://github.com/orgs/flatcar/teams/flatcar-security-team), a sub-set of the Maintainers team, and elected by the Maintainers (see [governance.md](./governance.md)).
+
+While the team actively researches and tracks new and existing security issues, it may also be notified of issues via [security@flatcar-linux.org](mailto:security@flatcar-linux.org).
+
+The Security team meets in a fortnightly cadence, in a private video call.
+The team maintains an internal list of security Primaries and Secondaries, which are rotated on a weekly basis. 
+Primary and Secondary are expected to actively engage in security work each day, including executing the Runbook (see below) and working on fixing ongoing security issues.
+
+Undisclosed security issues are tracked in a private repository only accessible by members of the security team.
+Public issues are tracked publicly in the project's main issue tracker.
+
+Security issues are addressed by releasing an updated OS image. Releases may be expedited depending on the issues' severity. For each release, release notes contain a concise list of security issues fixed. Also, a separate, detailed report on each of the issues addressed is part of every release.
 
 ## Daily security runbook for Security team primaries and secondaries
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -16,7 +16,6 @@ Security issues are addressed by releasing an updated OS image. Releases may be 
 ## Daily security runbook for Security team primaries and secondaries
 
 The runbook below discusses steps for identifying new potential security issues and for making the issues known to the Flatcar project's maintainers and / or the other members of the Security team.
-Embargoed issues are recorded in a private issue tracker only accessible by the Security team, while public issues are openly tracked in the [Flatcar project](https://github.com/Flatcar/Flatcar/issues).
 
 Primaries are expected to execute the runbook at least once per day, optionally assisted or off-loaded by Secondaries.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -9,6 +9,6 @@ Every day look into upstream security trackers like below:
 - oss-security mailing list
 - Golang announce mailing list
 - Rust security announcements
-- (optional) RedHat vulnerabilities
+- (optional) issue trackers of other distros
 - Whenever we discover any new CVE, we add it to an internal database, and use automation tools to create a new issue about the CVE in [Flatcar GitHub issues](https://github.com/Flatcar/Flatcar/issues) with labels `security` and `advisory`.
 - If an issue of updating the specific package affected by the new CVE is already open in [Flatcar GitHub issues](https://github.com/Flatcar/Flatcar/issues), then unfortunately we need to manually edit the existing issue to add the new CVE.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,14 @@
+# Flatcar Security 
+<todo - describe a security Schedule of tracking security issues of Flatcar>
+- Describe the process of tracking security issues for Flatcar, especially tracking issues from upstream projects like Gentoo Linux.
+
+## Primary person should do so:
+
+Every day look into upstream security trackers like below:
+- Gentoo security vulnerabilities. It might be useful to use gorss + RSS feed for this.
+- oss-security mailing list
+- Golang announce mailing list
+- Rust security announcements
+- (optional) RedHat vulnerabilities
+- If we see any new CVE, then add it to the CVE spreadsheets (still private), and click the link (above left) to generate new issues. Then we should be able to see a new issue created in Kinvolk security Github issues. (still private)
+- If the package of the new CVE is already open in Kinvolk security Github issues, then unfortunately we need to manually edit the existing issue to add the new CVE.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,7 +2,12 @@
 <todo - describe a security Schedule of tracking security issues of Flatcar>
 - Describe the process of tracking security issues for Flatcar, especially tracking issues from upstream projects like Gentoo Linux.
 
-## Primary person should do so:
+## Daily security runbook for Security team primaries and secondaries
+
+The runbook below discusses steps for identifying new potential security issues and for making the issues known to the Flatcar project's maintainers and / or the other members of the Security team.
+Embargoed issues are recorded in a private issue tracker only accessible by the Security team, while public issues are openly tracked in the [Flatcar project](https://github.com/Flatcar/Flatcar/issues).
+
+Primaries are expected to execute the runbook at least once per day, optionally assisted or off-loaded by Secondaries.
 
 Every day look into upstream security trackers like below:
 - Gentoo security vulnerabilities. It might be useful to use gorss + RSS feed for this.


### PR DESCRIPTION
Primary person should do so:

* Every day look into upstream security trackers like below:
  *  [Gentoo security vulnerabilities](https://bugs.gentoo.org/buglist.cgi?bug_status=__open__&component=Vulnerabilities&list_id=6015515&product=Gentoo%20Security). It might be useful to use `gorss` + RSS feed for this.
  *  [oss-security mailing list](https://oss-security.openwall.org/wiki/mailing-lists/oss-security)
  *  [Golang announce mailing list](https://groups.google.com/g/golang-announce)
  *  [Rust security announcements](https://groups.google.com/g/rustlang-security-announcements)
  *  (optional) issue trackers of other distros

* Whenever we discover any new CVE, we add it to an internal database, and use automation tools to create a new issue about the CVE in [Flatcar GitHub issues](https://github.com/Flatcar/Flatcar/issues) with labels `security` and `advisory`.
* If an issue of updating the specific package affected by the new CVE is already open in [Flatcar GitHub issues](https://github.com/Flatcar/Flatcar/issues), then unfortunately we need to manually edit the existing issue to add the new CVE.
