### PR TITLE
deleted archived repos from maintainers list

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -15,19 +15,9 @@ maintainers:
 * Gabriel Samfira @gabriel-samfira
 * Thilo Fromm @t-lo
 
-### coreos-overlay
-maintainers:
-* Krzesimir Nowak @krnowak
-* Thilo Fromm @t-lo
-
 ### flatcar-docs
 maintainers:
 * Kai Lüke @pothos
-* Thilo Fromm @t-lo
-
-### portage-stable
-maintainers:
-* Krzesimir Nowak @krnowak
 * Thilo Fromm @t-lo
 
 ### mantle

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -14,6 +14,7 @@ maintainers:
 * Kai Lüke @pothos
 * Gabriel Samfira @gabriel-samfira
 * Thilo Fromm @t-lo
+* Krzesimir Nowak @krnowak
 
 ### flatcar-docs
 maintainers:


### PR DESCRIPTION
I deleted both portage-stable and coreos-overlay repos from the list as they are archived.

