### PR TITLE
[EMERITUS_]MAINTAINERS.md: move wrl to emeritus

### DIFF
--- a/EMERITUS_MAINTAINERS.md
+++ b/EMERITUS_MAINTAINERS.md
@@ -4,4 +4,4 @@ This file lists contributors to the Flatcar project whose maintainership rests.
 It is meant to provide a fast-track back to active maintainer status should the emeritus decide to do so.
 
 
-**The list is currently empty**
+* William Light [@wrl](https://github.com/wrl)

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -32,7 +32,13 @@ maintainers:
 
 ### update_engine
 maintainers:
-* Willian Light @wrl
+* Kai Lüke @pothos
+* Dongsu Park @dongsupark
+
+### ue-rs
+maintainers:
+* Kai Lüke @pothos
+* Dongsu Park @dongsupark
 
 ### flatcar-linux-update-operator
 maintainers:


### PR DESCRIPTION
Move William Light to the `EMERITUS_MAINTAINERS.md` as per maintainer vote (simple majority).
wrl was removed from respective teams prior to this PR.

# TODO
After merge, run [sync-maintainers.py](https://github.com/flatcar/Flatcar/blob/main/sync-maintainers/sync-maintainers.py) to update subrepos.