### PR TITLE
MAINTAINERS.md: Add Adrian

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -15,6 +15,7 @@ maintainers:
 * Gabriel Samfira @gabriel-samfira
 * Thilo Fromm @t-lo
 * Krzesimir Nowak @krnowak
+* Adrian Vladu @ader1990
 
 ### flatcar-website
 maintainers:


### PR DESCRIPTION
This add Adrian Vladu as Flatcar maintainer. He was in charge of the Linux 6.6 update and all related tasks and wants to continue taking responsibilities. When merged we should also add him to the GitHub Org/teams so that he can create PRs from internal branches.

