### PR TITLE
MAINTAINERS.md: Add Ervin as Nebraska maintainer

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -22,6 +22,10 @@ maintainers:
 * Jeremi Piotrowski @jepio
 * James Le Cuirot @chewi
 
+### Nebraska
+maintainers:
+* Ervin Racz @ErvinRacz
+
 ### flatcar-website
 maintainers:
 * Kai Lüke @pothos


### PR DESCRIPTION
Add Ervin Racz as Nebraska maintainer to Maintainers.md. Vote on the Maintainers list succeeded.

When the PR is approved I'll run the [sync script](https://github.com/flatcar/Flatcar/blob/main/sync-maintainers/sync-maintainers.py) and add Ervin to the Github org's [Nebraska-maintainers](https://github.com/orgs/flatcar/teams/nebraska-maintainers) team.