### PR TITLE
ci: add link checking

### DIFF
--- a/.github/workflows/link-check.yaml
+++ b/.github/workflows/link-check.yaml
@@ -1,0 +1,23 @@
+name: link-checker 
+on:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  link-check:
+    name: Check Links
+    runs-on: ubuntu-22.04
+    steps:
+    - name: Check out code
+      uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+
+    - name: Check links
+      uses: lycheeverse/lychee-action@82202e5e9c2f4ef1a55a3d02563e1cb6041e5332  #v2.4.1
+      with:
+        fail: true
+        lycheeVersion: v0.19.1
+        args: --verbose --no-progress './**/*.md'
+
+

--- a/.lycheeignore
+++ b/.lycheeignore
@@ -1,0 +1,1 @@
+x.com/flatcar

--- a/CIS/level1-remediation_notes-2020-12-08.md
+++ b/CIS/level1-remediation_notes-2020-12-08.md
@@ -159,7 +159,7 @@ password user1 password1
 *               hard    core          0
 ```
 
-* sysctl (currently there is a bug for persistence of these settings https://github.com/kinvolk/Flatcar/issues/297)
+* sysctl (currently there is a bug for persistence of these settings https://github.com/flatcar/Flatcar/issues/297)
   * IP forwarding
 
 ```sysclt

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,7 @@
   * [Git and Github](#Git-and-Github)
   * [Start coding](#Start-coding)
   * [Proposing new features](#Proposing-new-features)
-  * [Authoring PRs](Authoring-PRs)
+  * [Authoring PRs](#Authoring-PRs)
   
 
 Welcome! We are glad that you want to contribute to our project! 💖
@@ -68,7 +68,7 @@ Though Matrix and Github discussions are encouraged and the preferred way to int
 
 We maintain a [Google Calendar](https://calendar.google.com/calendar/u/0/embed?src=c_ii991mqrpta9en8o7ofd4v19g4@group.calendar.google.com) ([iCal](https://calendar.google.com/calendar/ical/c_ii991mqrpta9en8o7ofd4v19g4%40group.calendar.google.com/public/basic.ics)) with both our Office Hours and Developer Sync meeting series which interested folks can comfortably import into the calendar app of their choice.
 
-Join us in our monthly [office hours meetings](../../discussions/categories/office-hours-agenda) to engage with the Flatcar User community interactively, to learn about the project's directions, and to discuss contributions. We also conduct the occasional user-focused demo of technologies related to image-based Linux.
+Join us in our monthly [office hours meetings](https://github.com/flatcar/Flatcar/discussions/categories/office-hours-agenda) to engage with the Flatcar User community interactively, to learn about the project's directions, and to discuss contributions. We also conduct the occasional user-focused demo of technologies related to image-based Linux.
 Lastly, the call includes a brief Release Planning with an update on the changes in the next immediate releases.
 
 If you'd like to share something or if you have a pressing issue you'd like discussed, please let us know.
@@ -79,7 +79,7 @@ Either comment on the respective meeting discussion, reach out to us on Matrix (
 The meeting time observes the Central European Time zone and is subject to summer time changes.
 It occurs at 3:30pm UTC, which may fluctuate in your timezone if you observe daylight saving time.
 
-Meeting agendas are published in advance - check our [discussions section](../../discussions/categories/office-hours-agenda) for examples.
+Meeting agendas are published in advance - check our [discussions section](https://github.com/flatcar/Flatcar/discussions/categories/office-hours-agenda) for examples.
 * Video call link: [https://meet.flatcar.org/OfficeHours](https://meet.flatcar.org/OfficeHours)
 * A Youtube live stream (which also serves as the meeting's recording) will be published on the respective agenda when a meeting starts.
 
@@ -92,16 +92,16 @@ It occurs at 3:30pm UTC, which may fluctuate in your timezone if you observe day
 While release planning is a recurring part of each community call we also conduct separate Developer Syncs for backlog grooming and task planning. We discuss Roadmap items, special projects, and day-to-day issues in these calls. If you want to participate and discuss or pick up work, that call is for you!
 Just like the Office Hours the call includes a brief Release Planning with an update on the changes in the next immediate releases.
 
-* Meeting agendas are published in advance - check our [discussions section](../../discussions/categories/flatcar-developer-sync) for examples.
+* Meeting agendas are published in advance - check our [discussions section](https://github.com/flatcar/Flatcar/discussions/categories/flatcar-developer-sync) for examples.
 * Call link: [https://meet.flatcar.org/OfficeHours](https://meet.flatcar.org/OfficeHours)
 * A youtube live stream (which also serves as the meeting's recording) will be published on the respective agenda when a meeting starts.
 
 ## Report bugs and request features
 
-Please file a respective [issue](issues) right here in the top-level Flatcar github project.
+Please file a respective [issue](https://github.com/flatcar/Flatcar/issues) right here in the top-level Flatcar github project.
 For instance, please use the "New Package Request" issue type to [file your request](https://github.com/flatcar/Flatcar/issues/new/choose). Please see [adding new packages to the Flatcar Linux OS image](adding-new-packages.md) for general guidelines.
 
-We have good first issues for new contributors and help wanted issues suitable for any contributor. [good first issue](https://github.com/flatcar/Flatcar/issues?q=is%3Aopen+is%3Aissue+label%3A%22good+first+issue%22) has extra information to help you make your first contribution. [help wanted](TODO) are issues suitable for someone who isn't a core maintainer and is good to move onto after
+We have good first issues for new contributors and help wanted issues suitable for any contributor. [good first issue](https://github.com/flatcar/Flatcar/issues?q=is%3Aopen+is%3Aissue+label%3A%22good+first+issue%22) has extra information to help you make your first contribution. [help wanted](https://github.com/flatcar/Flatcar/labels/help%20wanted) are issues suitable for someone who isn't a core maintainer and is good to move onto after
 your first pull request.
 
 Sometimes there won’t be any issues with these labels. That’s ok! There is likely still something for you to work on. If you want to contribute but you don’t know where to start or can't find a suitable issue, you can ⚠️ **explain how people can ask for an issue to work on**.

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ Check out our Matrix and Slack channels (mentioned above) for getting into conta
 
 We maintain a [Google Calendar](https://calendar.google.com/calendar/u/0/embed?src=c_ii991mqrpta9en8o7ofd4v19g4@group.calendar.google.com) ([iCal](https://calendar.google.com/calendar/ical/c_ii991mqrpta9en8o7ofd4v19g4%40group.calendar.google.com/public/basic.ics)) with both our Office Hours and Developer Sync meeting series which interested folks can comfortably import into the calendar app of their choice.
 
-Join us in our monthly [office hours meetings](../../discussions/categories/flatcar-office-hours) to engage with the Flatcar User community interactively, to learn about the project's directions, and to discuss contributions. We also conduct the occasional user-focused demo of technologies related to image-based Linux.
+Join us in our monthly [office hours meetings](https://github.com/flatcar/Flatcar/discussions/categories/flatcar-office-hours) to engage with the Flatcar User community interactively, to learn about the project's directions, and to discuss contributions. We also conduct the occasional user-focused demo of technologies related to image-based Linux.
 Lastly, the call includes a brief Release Planning with an update on the changes in the next immediate releases.
 
 If you'd like to share something or if you have a pressing issue you'd like discussed, please let us know.
@@ -100,7 +100,7 @@ Either comment on the respective meeting discussion, reach out to us on Matrix (
 
 **Flatcar Office Hours are on the second Wednesday of every month at 2:30pm UTC**
 
-* Meeting agendas are published in advance - check our [discussions section](../../discussions/categories/flatcar-office-hours) for examples.
+* Meeting agendas are published in advance - check our [discussions section](https://github.com/flatcar/Flatcar/discussions/categories/flatcar-office-hours) for examples.
 * Call link: [https://meet.flatcar.org/OfficeHours](https://meet.flatcar.org/OfficeHours)
 * A Youtube live stream (which also serves as the meeting's recording) will be published on the respective agenda when a meeting starts.
 
@@ -110,7 +110,7 @@ Either comment on the respective meeting discussion, reach out to us on Matrix (
 While release planning is a recurring part of each community call we also conduct separate Developer Syncs for backlog grooming and task planning. We discuss Roadmap items, special projects, and day-to-day issues in these calls. If you want to participate and discuss or pick up work, that call is for you!
 Just like the Office Hours the call includes a brief Release Planning with an update on the changes in the next immediate releases.
 
-* Meeting agendas are published in advance - check our [discussions section](../../discussions/categories/flatcar-developer-sync) for examples.
+* Meeting agendas are published in advance - check our [discussions section](https://github.com/flatcar/Flatcar/discussions/categories/flatcar-developer-sync) for examples.
 * Call link: [https://meet.flatcar.org/OfficeHours](https://meet.flatcar.org/OfficeHours)
 * A youtube live stream (which also serves as the meeting's recording) will be published on the respective agenda when a meeting starts.
 
@@ -120,7 +120,7 @@ Flatcar Container Linux follows an Alpha-Beta-Stable release process. New featur
 
 Note that unlike features, bug fixes for any release channel will be released to that respective channel directly, i.e. Alpha bug fixes will be included in the next Alpha, Beta fixes will directly go to Beta, and Stable fixes will be released with the next Stable.
 
-We plan our releases in a 14-day cadence. The maintainer team holds fortnightly release meetings - both as recurring part of our monthly [community calls](tree/main/community-meetings/) as well as a separate meeting in-between the monthly community call cadence. Up-to-date planning status is reflected in our [release planning board](https://github.com/orgs/flatcar/projects/7).
+We plan our releases in a 14-day cadence. The maintainer team holds fortnightly release meetings - both as recurring part of our monthly [community calls](https://github.com/flatcar/Flatcar/discussions/categories/flatcar-office-hours) as well as a separate meeting in-between the monthly community call cadence. Up-to-date planning status is reflected in our [release planning board](https://github.com/orgs/flatcar/projects/7).
 
 ### LTS
 

--- a/governance.md
+++ b/governance.md
@@ -146,7 +146,7 @@ for that purpose.
 
 ## Code of Conduct
 
-[Code of Conduct](./code-of-conduct.md)
+[Code of Conduct](./CODE_OF_CONDUCT.md)
 violations by community members will be discussed and resolved
 on the [private Maintainer mailing list](maintainers@flatcar-linux.org).  If a Maintainer is directly involved
 in the report, the Maintainers will instead designate two Maintainers to work

--- a/interop-matrix.md
+++ b/interop-matrix.md
@@ -60,7 +60,7 @@ Please propose ownership by filing a PR for this document.
 
 | Environment | Full-Feature (release blocker) | Works | Tested (CI) | Owner | Reference (e.g. GH issue) | Notes |
 |-------------|--------------------------------|-------|-------------|-------|---------------------------|-------|
-| AKS Engine  |                                |   X   |             | [no owner] |                      | https://kinvolk.io/blog/2020/12/supercharging-aks-engine-with-flatcar-container-linux/ |
+| AKS Engine  |                                |   X   |             | [no owner] |                      | https://kinvolk.io/blog/2020/12/aks-engine-on-flatcar/ |
 | Rancher (rke) |                              |   X   |             | [no owner] |                      |       |
 | Rancher (rke2) |                             |       |             | [no owner] |                      |       |
 | Lokomotive |                X                |   X   |      X      | @kinvolk/lokomotive-developers |  |       |

--- a/lychee.toml
+++ b/lychee.toml
@@ -1,0 +1,1 @@
+exclude_path = ["attic"]


### PR DESCRIPTION
# Add link checking for CI

This adds link checking via `lychee` to ensure that links within the repository are valid (existing and new). This will ensure that data remains up to date as the repository continues to evolve.

## How to use

Open a pull request and you can see links being checked. Additionally you can run this locally if you have [lychee](https://github.com/lycheeverse/lychee) on your system

## Testing done

Ran lychee locally and addressed all existing issues

- [X] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
- [X] Inspected CI output for image differences: `/boot` and `/usr` size, packages, list files for any missing binaries, kernel modules, config files, kernel modules, etc.