### PR TITLE
Add Robin Schneider as a Flatcar Maintainer

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -24,6 +24,7 @@ Official Flatcar project maintainers. All maintainers listed here should also be
 | Ervin Racz        | [@ervcz](https://github.com/ervcz)                     |
 | Jan Bronicki      | [@John15321](https://github.com/John15321)             |
 | Lexi Nadolski     | [@lexinadolski](https://github.com/lexinadolski)       |
+| Robin Schneider   | [@robinschneider](https://github.com/robinschneider)   |
 
 ## Flatcar Security Team
 


### PR DESCRIPTION
This PR adds Robin Schneider (@robinschneider) as a Flatcar maintainer. Adding Robin was proposed on the Maintainers private email list, the vote was successful (simple majority, no dissentient vote).

The CNCF registries will be updated shortly. 

---

Proposal for reference:

Hello team,

I would like to propose including Robin Schneider[1] as a Flatcar
maintainer. Robin has been a very active participant in the Flatcar
community, regularly helping users, sharing practical feedback, and
contributing to discussions across several areas of the project. He has
also contributed to Flatcar infrastructure and provider enablement work,
and has expressed interest in supporting the infrastructure side of the
project wherever possible. Having him within the maintainer team will
greatly help the project.

Some of Robin's work includes:
- Adding STACKIT as a supported cloud provider for Flatcar by providing
the OEM image integration[2]
- Adding STACKIT provider testing support and CI automation for vendor
testing[3]
- Documenting Flatcar usage on STACKIT for users and operators[4]
- Improving the development workflow by fixing the SDK container startup
on macOS[5]
- Updating the NVIDIA GPU usage documentation, including installation,
container verification, and Kubernetes usage[6]
- Investigating and driving work around getting the NVIDIA GPU Operator
working on Flatcar[7]
- Actively participating in the Flatcar community, helping users, and
bringing practical production-user feedback to the project

Please submit your vote via this email.

[1] https://github.com/robinschneider
[2] https://github.com/flatcar/scripts/pull/3018
[3] https://github.com/flatcar/scripts/pull/3287
[4] https://github.com/flatcar/flatcar-website/pull/456
[5] https://github.com/flatcar/scripts/pull/3814
[6] https://github.com/flatcar/flatcar-website/pull/515
[7] https://github.com/flatcar/Flatcar/issues/1962