### PR TITLE
fix sync-maintainers parser for subgroup table format

### DIFF
--- a/sync-maintainers/sync-maintainers.py
+++ b/sync-maintainers/sync-maintainers.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+import re
 import requests
 import json
 import subprocess
@@ -6,27 +7,43 @@ import os
 import sys
 import argparse
 
+MEMBER_LINK = re.compile(r"\[@([^\]]+)\]\(https://github\.com/[^)]+\)")
+REPO_LINK = re.compile(r"\[[^\]]+\]\(https://github\.com/flatcar/([^)/\s]+)\)")
 
-def parse(m):
+
+def parse_subgroup_repos(lines):
+    repos = {}
+    in_subgroups = False
+    for line in lines:
+        if line.startswith("## Maintainer Subgroups"):
+            in_subgroups = True
+            continue
+        if in_subgroups and line.startswith("##"):
+            break
+        if not in_subgroups or not line.startswith("| **"):
+            continue
+        parts = line.split("|")
+        if len(parts) < 5:
+            continue
+        maintainers = [
+            f"* @{match.group(1)}" for match in MEMBER_LINK.finditer(parts[3])
+        ]
+        for match in REPO_LINK.finditer(parts[4]):
+            repo_name = match.group(1)
+            if repo_name == "Flatcar":
+                continue
+            repos[repo_name] = maintainers
+    return sorted(repos.items())
+
+
+def parse(lines):
     para = []
-    repos = []
-    while len(m):
-        line = m.pop(0)
-        if line == "# Maintainers":
-            line = m.pop(0)
-            while not line.startswith("#"):
-                para.append(line)
-                line = m.pop(0)
-        if line.startswith("###"):
-            repo = line.split("### ")[1].strip()
-            maint = []
-            m.pop(0)  # maintainers:
-            line = m.pop(0)
-            while line.startswith("* "):
-                maint.append(line)
-                line = m.pop(0) if len(m) else ""
-            if repo != "Flatcar":
-                repos.append((repo, maint))
+    if lines and lines[0] == "# Maintainers":
+        idx = 1
+        while idx < len(lines) and not lines[idx].startswith("#"):
+            para.append(lines[idx])
+            idx += 1
+    repos = parse_subgroup_repos(lines)
     return para, repos
 
 
@@ -163,7 +180,7 @@ def main_github(args):
         if resp.status_code != 201:
             print(resp.json())
         else:
-            print("{repo_name} ok")
+            print(f"{repo_name} ok")
 
 
 def main_list(args):


### PR DESCRIPTION
# Fix sync-maintainers parser for the new MAINTAINERS.md layout

Fixes #2227

The central `MAINTAINERS.md` file was rewritten to use maintainer subgroup tables. `sync-maintainers.py` still parsed the old `### repo` block format, so `./sync-maintainers.py list` printed nothing and the `repo` and `github` commands had no repos to work on.

This change parses repos and maintainers from the Maintainer Subgroups table instead. Maintainer entries are written as `* @user` lines so the existing `get_assignees()` logic still works. Also fixes the success log that was printing the literal text `{repo_name} ok`.

## How to use

From the `sync-maintainers/` directory, install dependencies and run the list command.

```
pip install -r requirements.txt
./sync-maintainers.py list
```

You should see 15 repo names from the subgroup table (nebraska, mantle, sysext-bakery, and the rest). Before this change the command returned no output. Cross check that list against the Repositories column in the Maintainer Subgroups table in `MAINTAINERS.md`.

## Testing done

Ran from `sync-maintainers/` on Windows with Python 3.

```
pip install -r requirements.txt
./sync-maintainers.py list
```

Output:

```
flatcar-app-jitsi
flatcar-app-minecraft
flatcar-linux-build-secrets
flatcar-linux-infra
flatcar-linux-infra-secrets
flatcar-maintainer-private
flatcar-socials
flatcar-website
go-omaha
jenkins-os
jenkins-secret
mantle
nebraska
nebraska-update-agent
sysext-bakery
```

Also verified in Python that `parse_maintainers()` returns 15 repos, the intro paragraph is still read correctly, and `nebraska` gets the six maintainers from the nebraska-maintainers subgroup row with valid assignee usernames.

- [ ] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
- [ ] Inspected CI output for image differences: `/boot` and `/usr` size, packages, list files for any missing binaries, kernel modules, config files, kernel modules, etc.

Not applicable for this change. This PR only touches the maintainer sync script in the Flatcar meta repo.

<!-- For coreos-overlay ebuild modifications that include a CROS_WORKON_COMMIT bump, did you bump too the ebuild revision ? -->
