### PR TITLE
Fix typo in CIS/README.md reports section

### DIFF
--- a/CIS/README.md
+++ b/CIS/README.md
@@ -45,7 +45,7 @@ But then there are things that should be fixed in the benchmark, because they fa
 
 ## Reports
 
-Here the too reports, and the corresponding notes we have produced:
+Here are the two reports, and the corresponding notes we have produced:
 
 * [2020-12-08 level1 report](./inspec-report-level1-root-2020-12-08.txt) -- [remediation notes](./level1-remediation_notes-2020-12-08.md)
 * [2020-12-08 level2 report](./inspec-report-level2-root-2020-12-08.txt) -- _(no remediation notes yet)_


### PR DESCRIPTION
# Fix typo in CIS/README.md reports section

Fixes a typo on line 48 of `CIS/README.md`. The text said "Here the too reports" and now reads "Here are the two reports".

#2232

This is a one-line documentation fix in the CIS benchmarking readme. No code or behavior changes.

## How to use

Open `CIS/README.md` and scroll to the Reports section near the bottom. The intro sentence under `## Reports` should read correctly in English.

## Testing done

Read the updated line in `CIS/README.md` and confirmed the sentence is grammatically correct.

- [ ] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
- [ ] Inspected CI output for image differences: `/boot` and `/usr` size, packages, list files for any missing binaries, kernel modules, config files, kernel modules, etc.

Not applicable. Documentation only.

<!-- For coreos-overlay ebuild modifications that include a CROS_WORKON_COMMIT bump, did you bump too the ebuild revision ? -->
