### PR TITLE
Add error handling for subprocess, file I/O, and network calls in sync-maintainers.py

### DIFF
--- a/sync-maintainers/sync-maintainers.py
+++ b/sync-maintainers/sync-maintainers.py
@@ -167,7 +167,7 @@ def main_github(args):
             if resp.status_code != 201:
                 print(resp.json())
             else:
-                print("{repo_name} ok")
+                print(f"{repo_name} ok")
         except requests.RequestException as e:
             print(f"Error syncing {repo_name}: {e}", file=sys.stderr)
 

--- a/sync-maintainers/sync-maintainers.py
+++ b/sync-maintainers/sync-maintainers.py
@@ -95,12 +95,15 @@ def parse_maintainers(repo=None):
 def main_repo(args):
     repos, paragraph = parse_maintainers(args.repo)
     for (repo_name, maintainers) in repos:
-        repo_url = f"git@github.com:flatcar/{repo_name}"
-        subprocess.run(["git", "clone", "--depth=1", repo_url])
-        checkout_branch(repo_name)
-        write_maintainers_file(repo_name, paragraph, maintainers)
-        commit(repo_name)
-        push(repo_name)
+        try:
+            repo_url = f"git@github.com:flatcar/{repo_name}"
+            subprocess.run(["git", "clone", "--depth=1", repo_url])
+            checkout_branch(repo_name)
+            write_maintainers_file(repo_name, paragraph, maintainers)
+            commit(repo_name)
+            push(repo_name)
+        except (subprocess.CalledProcessError, OSError) as e:
+            print(f"Error syncing {repo_name}: {e}", file=sys.stderr)
 
 
 def prepare_req(repo, token, api):
@@ -152,18 +155,21 @@ def main_github(args):
         raise Exception("Missing GITHUB_TOKEN env variable")
     repos, _ = parse_maintainers(args.repo)
     for (repo_name, maintainers) in repos:
-        pr = get_pr(repo_name, token).json()
-        if not pr:
-            print(f"{repo_name} creating pr")
-            base = get_default_branch(repo_name, token)
-            pr = [create_pr(repo_name, token, base).json()]
-        prnum = pr[0]["number"]
-        assignees = get_assignees(maintainers)
-        resp = update_assignees(repo_name, token, prnum, assignees)
-        if resp.status_code != 201:
-            print(resp.json())
-        else:
-            print("{repo_name} ok")
+        try:
+            pr = get_pr(repo_name, token).json()
+            if not pr:
+                print(f"{repo_name} creating pr")
+                base = get_default_branch(repo_name, token)
+                pr = [create_pr(repo_name, token, base).json()]
+            prnum = pr[0]["number"]
+            assignees = get_assignees(maintainers)
+            resp = update_assignees(repo_name, token, prnum, assignees)
+            if resp.status_code != 201:
+                print(resp.json())
+            else:
+                print("{repo_name} ok")
+        except requests.RequestException as e:
+            print(f"Error syncing {repo_name}: {e}", file=sys.stderr)
 
 
 def main_list(args):

--- a/sync-maintainers/sync-maintainers.py
+++ b/sync-maintainers/sync-maintainers.py
@@ -97,7 +97,7 @@ def main_repo(args):
     for (repo_name, maintainers) in repos:
         try:
             repo_url = f"git@github.com:flatcar/{repo_name}"
-            subprocess.run(["git", "clone", "--depth=1", repo_url])
+            subprocess.run(["git", "clone", "--depth=1", repo_url], check=True)
             checkout_branch(repo_name)
             write_maintainers_file(repo_name, paragraph, maintainers)
             commit(repo_name)


### PR DESCRIPTION
## Summary

`sync-maintainers.py` currently lacks error handling around subprocess execution, file I/O, and GitHub API requests. A failure while processing a single repository causes the entire synchronization process to terminate.

This PR adds targeted error handling so failures are reported with repository context while allowing the remaining repositories to continue processing.

## Changes

### `main_repo()`

- Wrap the per-repository processing in a `try/except` block.
- Handle `subprocess.CalledProcessError` and `OSError`.
- Log the repository name and error message to `stderr`.
- Continue processing the remaining repositories.

### `main_github()`

- Wrap the per-repository GitHub operations in a `try/except` block.
- Handle `requests.RequestException`.
- Log the repository name and error message to `stderr`.
- Continue processing the remaining repositories.

## Why

Previously, a failure in one repository aborted the entire synchronization process. This change isolates failures to the affected repository while preserving the existing behavior for successful runs.