### PR TITLE
fix: add missing quotes to end_date assignment in metrics workflow

### DIFF
--- a/.github/workflows/issue-pr-contrib-metrics.yaml
+++ b/.github/workflows/issue-pr-contrib-metrics.yaml
@@ -32,7 +32,7 @@ jobs:
           set -euo pipefail
           if [[ -n "${{inputs.start_date}}" && -n "${{inputs.end_date}}" ]] ; then
             start_date="${{inputs.start_date}}"
-            end_date=${{inputs.end_date}}
+            end_date="${{inputs.end_date}}"
           else
             start_date=$(date -d "last month" +%Y-%m-%d)
             end_date=$(date -d "yesterday" +%Y-%m-%d)


### PR DESCRIPTION
Resolves a syntax issue in `.github/workflows/issue-pr-contrib-metrics.yaml` by adding missing string interpolation quotes to the `end_date` variable assignment. 

Previously, `start_date` was properly quoted (`start_date="${{inputs.start_date}}"`), but `end_date` was assigned without quotes (`end_date=${{inputs.end_date}}`). This change prevents potential parsing errors or workflow failures if action inputs evaluate to an empty string or contain spaces.
