### PR TITLE
Fix typos in monthly contributor report text

### DIFF
--- a/.github/workflows/issue-pr-contrib-metrics.yaml
+++ b/.github/workflows/issue-pr-contrib-metrics.yaml
@@ -318,7 +318,7 @@ jobs:
           echo -e '\n\n<h1 id="discussions-metrics">Discussions Metrics</h1>' >> summary_report.md
           echo -e '\n<h2 id="discussions-metrics-qna">Questions & Answers</h2>' >> summary_report.md
           echo -e "\n### Summary of all unanswered Questions" >> summary_report.md
-          echo "These summary statistics include all currently unanswered Q&A discussions (openend at any point in the past)." \
+          echo "These summary statistics include all currently unanswered Q&A discussions (opened at any point in the past)." \
               >> summary_report.md
           # remove full discussions list from stats; we only want the summary
           tail --lines=+2 discussion_qna_open.md \
@@ -326,7 +326,7 @@ jobs:
               >> summary_report.md
 
           echo -e "\n### Summary of all answered Questions" >> summary_report.md
-          echo -e "\nThese Q&A discussions were openend and also answered between ${{ env.START_DATE }} - ${{ env.END_DATE }}." \
+          echo -e "\nThese Q&A discussions were opened and also answered between ${{ env.START_DATE }} - ${{ env.END_DATE }}." \
               >> summary_report.md
           echo -e "(Discussions search is somewhat limited on Github; there's currently no way to search for discussions answered within a given timespan)" \
               >> summary_report.md
@@ -343,7 +343,7 @@ jobs:
 
           echo -e '\n<h2 id="discussions-metrics-other">Other Discussions</h2>' >> summary_report.md
           echo -e "\n### Summary of open Discussions" >> summary_report.md
-          echo "These summary statistics include all currently open discussions except Q&A (openend at any point in the past)." \
+          echo "These summary statistics include all currently open discussions except Q&A (opened at any point in the past)." \
               >> summary_report.md
           # remove full discussions list from stats; we only want the summary
           tail --lines=+2 discussion_open.md \
@@ -373,12 +373,12 @@ jobs:
           tail --lines=+2 advisories_opened.md >> summary_report.md
 
           echo -e '\n<h2 id="advisory-metrics-closed">Advisories closed</h2>' >> summary_report.md
-          echo -e "\nThese advisories were openend at any point in the past and were closed between ${{ env.START_DATE }} - ${{ env.END_DATE }}." \
+          echo -e "\nThese advisories were opened at any point in the past and were closed between ${{ env.START_DATE }} - ${{ env.END_DATE }}." \
               >> summary_report.md
           tail --lines=+2 advisories_closed.md >> summary_report.md
 
-          echo -e '\n<h2 id="advisory-metrics-summary">All open Advisoriess</h2>' >> summary_report.md
-          echo "These statistics cover all open advisories (openend at any point in the past)." \
+          echo -e '\n<h2 id="advisory-metrics-summary">All open Advisories</h2>' >> summary_report.md
+          echo "These statistics cover all open advisories (opened at any point in the past)." \
               >> summary_report.md
           tail --lines=+2 advisories_open.md >> summary_report.md
 
@@ -388,7 +388,7 @@ jobs:
           echo -e '\n\n<h1 id="issue-metrics">Issue Metrics</h1>' >> summary_report.md
 
           echo -e '\n<h2 id="issue-metrics-summary">Summary of all open Issues</h2>' >> summary_report.md
-          echo "These summary statistics include all currently open issues (openend at any point in the past)." \
+          echo "These summary statistics include all currently open issues (opened at any point in the past)." \
               >> summary_report.md
           # remove full issues list from stats; we only want the summary
           tail --lines=+2 issues_open.md \
@@ -401,7 +401,7 @@ jobs:
           tail --lines=+2 issues_opened.md >> summary_report.md
 
           echo -e '\n<h2 id="issue-metrics-closed">Issues closed</h2>' >> summary_report.md
-          echo -e "\nThese issues were openend at any point in the past and were closed between ${{ env.START_DATE }} - ${{ env.END_DATE }}." \
+          echo -e "\nThese issues were opened at any point in the past and were closed between ${{ env.START_DATE }} - ${{ env.END_DATE }}." \
               >> summary_report.md
           tail --lines=+2 issues_closed.md >> summary_report.md
 
@@ -419,7 +419,7 @@ jobs:
           echo -e '\n\n<h1 id="pr-metrics">Pull Requests Metrics</h1>' >> comment_report.md
 
           echo -e '\n<h2 id="pr-metrics-summary">Summary of all open PRs</h2>' >> comment_report.md
-          echo "These summary statistics include all currently open PRs (openend at any point in the past)." \
+          echo "These summary statistics include all currently open PRs (opened at any point in the past)." \
               >> comment_report.md
           # remove full PRs list from stats; we only want the summary
           tail --lines=+2 prs_open.md \
@@ -432,7 +432,7 @@ jobs:
           tail --lines=+2 prs_opened.md >> comment_report.md
 
           echo -e '\n<h2 id="pr-metrics-closed">PRs closed</h2>' >> comment_report.md
-          echo -e "\nThese PRs were openend at any point in the past and were closed between ${{ env.START_DATE }} - ${{ env.END_DATE }}." \
+          echo -e "\nThese PRs were opened at any point in the past and were closed between ${{ env.START_DATE }} - ${{ env.END_DATE }}." \
               >> comment_report.md
           tail --lines=+2 prs_closed.md >> comment_report.md
   


### PR DESCRIPTION

The monthly metrics workflow assembles a report and posts it as a GitHub issue. A few strings in that assembly step had spelling mistakes that show up in the published report every month.

This change fixes "openend" to "opened" in nine places across the Q&A, discussions, advisories, issues, and PR sections. It also fixes the advisory summary heading from "All open Advisoriess" to "All open Advisories".

Only the echo strings in `.github/workflows/issue-pr-contrib-metrics.yaml` change. Nothing else about how the workflow runs or what it counts.

## How to use

Open `.github/workflows/issue-pr-contrib-metrics.yaml` and search for "opened" in the "Assemble full report" step. The old typos "openend" and "Advisoriess" should be gone.

You can also diff against main and confirm the change is limited to those report strings.

## Testing done

Searched the workflow file to confirm "openend" and "Advisoriess" no longer appear anywhere in it.

```text
grep openend issue-pr-contrib-metrics.yaml   → no matches
grep Advisoriess issue-pr-contrib-metrics.yaml → no matches
```

Did not run the full workflow locally since it needs org secrets and the metrics action inputs. The next scheduled run or a manual workflow dispatch will pick up the corrected text automatically.

- [ ] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
- [ ] Inspected CI output for image differences: `/boot` and `/usr` size, packages, list files for any missing binaries, kernel modules, config files, kernel modules, etc.


<!-- For coreos-overlay ebuild modifications that include a CROS_WORKON_COMMIT bump, did you bump too the ebuild revision ? -->
