### PR TITLE
docs: remove EOL'd Lokomotive entry from interop-matrix

### DIFF
--- a/interop-matrix.md
+++ b/interop-matrix.md
@@ -63,7 +63,6 @@ Please propose ownership by filing a PR for this document.
 | AKS Engine  |                                |   X   |             | [no owner] |                      | https://kinvolk.io/blog/2020/12/supercharging-aks-engine-with-flatcar-container-linux/ |
 | Rancher (rke) |                              |   X   |             | [no owner] |                      |       |
 | Rancher (rke2) |                             |       |             | [no owner] |                      |       |
-| Lokomotive |                X                |   X   |      X      | @kinvolk/lokomotive-developers |  |       |
 | Tanzu KG |                                   |   X   |             | [no owner] |                      |       |
 | K3s |                                        |   X   |             | [no owner] |                      |       |
 | EKS-Distro |                                 |   X   |             | [no owner] |                      |       |


### PR DESCRIPTION


## Why

Lokomotive was sunset years ago, but it was still listed as a supported Kubernetes distro in interop-matrix.md, with @kinvolk/lokomotive-developers listed as the owning team. That team doesn't exist anymore, so the entry is just a dead link waiting to confuse someone who's actually trying to use this doc to find an owner.

Relates to #1484.

## What changed

- Removed the Lokomotive row from the "Kubernetes Distros" table in `interop-matrix.md`.

## Notes

- This closes out the flatcar/Flatcar-repo instance of stale Lokomotive  references. It does **not** close #1484 fully — the issue's own  checklist points at an org-wide code search
  (https://github.com/search?q=org%3Aflatcar+lokomotive&type=code) thatstill turns up 4 more stale references (identical "used later in Lokomotive configuration" help text) in `flatcar/flatcar-website` and
  `flatcar/flatcar-cloud-image-uploader`. Those need separate PRs in  those repos, so I'd leave #1484 open until that follow-up lands rather than auto-closing it from this PR.
- I left the two Lokomotive mentions in  `attic/community-meetings/2021-05-11.md` alone — that's an archived
  meeting transcript, not living documentation, so editing it would be rewriting history rather than tidying up stale docs.
- Small, single-line change — nothing else to flag here.
