### PR TITLE
fix(sync-maintainers): add missing f-string prefix in print statement

### DIFF
--- a/sync-maintainers/sync-maintainers.py
+++ b/sync-maintainers/sync-maintainers.py
@@ -163,7 +163,7 @@ def main_github(args):
         if resp.status_code != 201:
             print(resp.json())
         else:
-            print("{repo_name} ok")
+            print(f"{repo_name} ok")
 
 
 def main_list(args):


### PR DESCRIPTION
This PR fixes a minor string formatting bug in the `sync-maintainers/sync-maintainers.py` script. 

Previously, if updating the assignees was successful, the script would output the literal string `"{repo_name} ok"` because it was missing the `f` prefix required to format it. By adding the `f` prefix, it will now correctly print the actual repository name (e.g., `"scripts ok"`).

## How to use

No usage changes are required. Reviewers can validate this PR by simply inspecting the one-line fix on line 166 to ensure it's a valid Python f-string.

## Testing done

Visually inspected the syntax to ensure it's valid Python. Since this is an internal maintenance script, it can be tested locally by running `python sync-maintainers.py github --repo <some-test-repo>` (with a valid `GITHUB_TOKEN`) and observing the console output upon a successful run.

- [ ] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
- [ ] Inspected CI output for image differences: `/boot` and `/usr` size, packages, list files for any missing binaries, kernel modules, config files, kernel modules, etc.

