### PR TITLE
docs: fix CoC contact link and CNCF name in CODE_OF_CONDUCT.md

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -2,4 +2,4 @@
 
 We follow the [CNCF Code of Conduct](https://github.com/cncf/foundation/blob/main/code-of-conduct.md).
 
-Please contact [private Maintainer mailing list](maintainers@flatcar-linux.org) or the Cloud Native Foundation mediator, conduct@cncf.io, to report an issue.
+Please contact [private Maintainer mailing list](mailto:maintainers@flatcar-linux.org) or the Cloud Native Computing Foundation mediator, conduct@cncf.io, to report an issue.


### PR DESCRIPTION
## Why

CODE_OF_CONDUCT.md had two small but real problems in its contact line:

1. The `private Maintainer mailing list` link was missing the `mailto:` scheme, so instead of opening an email client it rendered as a broken/relative link. This is the same bug that was just fixed in  governance.md (#2244) - just in a different file.
2. "Cloud Native Foundation" is not a real organization - CNCF stands for Cloud Native **Computing** Foundation, and that's the name used correctly everywhere else in this repo (see README.md, governance.md).

## What changed

- `CODE_OF_CONDUCT.md`: added `mailto:` to the maintainer mailing list  link, and corrected "Cloud Native Foundation" to "Cloud Native  Computing Foundation".

## Open question / not addressed here

While looking at this I noticed the three docs that describe how to report a CoC violation each name a *different* secondary contact:

- README.md points to a named Linux Foundation mediator (Mishi Choudhary)
- CODE_OF_CONDUCT.md points to a generic CNCF email (conduct@cncf.io)
- governance.md points to an unnamed CNCF Code of Conduct Committee

I don't know which of these is actually current/correct, so I'm not guessing at a reconciliation here - this PR only fixes the mechanical link/name issues. Flagging in case a maintainer wants to pick one canonical contact path across all three files as a follow-up.

---
