### PR TITLE
docs: fix broken interop-matrix.md link in 2021-05-11 community call …

### DIFF
--- a/attic/community-meetings/2021-05-11.md
+++ b/attic/community-meetings/2021-05-11.md
@@ -33,7 +33,7 @@ The meeting largely followed the [slide deck](2021-05-11-slides.pdf). After the 
    - “[...] we want to assure the Flatcar community that Microsoft and the Kinvolk team will continue to collaborate with the larger Flatcar community on the evolution of Flatcar Container Linux.” - Brendan Burns, Microsoft
    - “This will not be a replay of the movie you’ve seen before. In fact, we and Microsoft are committed to doubling down on the Flatcar community: we want to expand the universe of partners, contributors, and users, to ensure a vibrant, successful and sustainable long-term future for Flatcar as a truly open, community-driven project.” - Chris Kühl, Kinvolk
 3. Thilo introduces monthly community calls and the new community focus of the Flatcar project, overcoming and leaving behind its single vendor past.
-4. Marga introduces the [interop matrix](../interop-matrix.md) as a means to track Flatcar's support of runtime environments (clouds, on premise, etc.).
+4. Marga introduces the [interop matrix](../../interop-matrix.md) as a means to track Flatcar's support of runtime environments (clouds, on premise, etc.).
    - Some environments, while supported, do not currently have an owner.
    - The project aims to have community owners who operate workloads / clusters in the respective environments, in the long term.
 5. Andy elaborates on Flatcar's core philosophy and shares details on stabilisation process and on release cadence.


### PR DESCRIPTION



## Why

The 2021-05-11 community call notes link to the interop matrix doc with a relative path that's one directory level short (`../interop-matrix.md`), which resolves to `attic/interop-matrix.md` and doesn't exist, so the link 404s.

## What changed

`interop-matrix.md` actually lives at the repo root, two directories up from `attic/community-meetings/`, not one. Fixed
the link to `../../interop-matrix.md`.

## Notes

Single-line link fix. Checked open PR #2243, which also touches `interop-matrix.md` (removing an unrelated Lokomotive entry) but not this attic file, so there's no overlap.
