### PR TITLE
docs: fix subject-verb typo in adding-new-packages.md

### DIFF
--- a/adding-new-packages.md
+++ b/adding-new-packages.md
@@ -2,7 +2,7 @@
 
 Flatcar Container Linux is a modern Linux distribution for running container workloads.
 To stay modern, the packages included need to be kept up-to-date, and sometimes new packages introduced.
-This documents explains the process for the latter.
+This document explains the process for the latter.
 
 ## Project definition
 


### PR DESCRIPTION

## Why

The intro paragraph in adding-new-packages.md has a subject-verb agreement typo: "This documents explains the process for the latter," mismatching the singular "document" with the plural verb "explains".

## What changed

Fixed the sentence to "This document explains the process for the latter."

## Notes

Single-word typo fix, one line changed. README.md links to this file twice as a plain file reference (not an anchor), so those links are unaffected.
