### PR TITLE
sync-maintainers: refactor and harden maintainer synchronization tooling

### DIFF
--- a/.github/workflows/sync-maintainers-test.yml
+++ b/.github/workflows/sync-maintainers-test.yml
@@ -1,0 +1,36 @@
+name: Sync Maintainers Tests
+
+on:
+  push:
+    branches: [ main, refactor/sync-maintainers ]
+    paths:
+      - 'sync-maintainers/**'
+      - '.github/workflows/sync-maintainers-test.yml'
+  pull_request:
+    branches: [ main ]
+    paths:
+      - 'sync-maintainers/**'
+      - '.github/workflows/sync-maintainers-test.yml'
+
+jobs:
+  test:
+    name: Run Unit Tests
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r sync-maintainers/requirements.txt
+
+      - name: Run unit tests
+        run: |
+          python -m unittest discover -s sync-maintainers -v

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+*.pyc
+venv/

--- a/sync-maintainers/sync-maintainers.py
+++ b/sync-maintainers/sync-maintainers.py
@@ -1,10 +1,26 @@
 #!/usr/bin/env python3
-import requests
-import json
-import subprocess
-import os
-import sys
 import argparse
+import json
+import os
+import subprocess
+import sys
+import requests
+from requests.adapters import HTTPAdapter
+from urllib3.util.retry import Retry
+
+
+def get_session():
+    session = requests.Session()
+    retries = Retry(
+        total=5,
+        backoff_factor=1,
+        status_forcelist=[429, 500, 502, 503, 504],
+        raise_on_status=False,
+    )
+    adapter = HTTPAdapter(max_retries=retries)
+    session.mount("https://", adapter)
+    session.mount("http://", adapter)
+    return session
 
 
 def parse(m):
@@ -53,6 +69,16 @@ def write_maintainers_file(repo_name, paragraph, maintainers):
 BRANCH_NAME = "sync-maintainers"
 
 
+def clone_repo(repo_name):
+    ssh_url = f"git@github.com:flatcar/{repo_name}"
+    https_url = f"https://github.com/flatcar/{repo_name}.git"
+    try:
+        subprocess.run(["git", "clone", "--depth=1", ssh_url], check=True)
+    except subprocess.CalledProcessError:
+        print(f"SSH clone failed for {repo_name}, falling back to HTTPS...")
+        subprocess.run(["git", "clone", "--depth=1", https_url], check=True)
+
+
 def checkout_branch(repo_name):
     return subprocess.run(
         ["git", "-C", repo_name, "checkout", "-B", BRANCH_NAME, "origin/HEAD"],
@@ -81,8 +107,18 @@ def push(repo_name):
     )
 
 
-def parse_maintainers(repo=None):
-    maint_file = "../MAINTAINERS.md"
+def parse_maintainers(repo=None, maint_file="../MAINTAINERS.md"):
+    if not os.path.isabs(maint_file) and not os.path.exists(maint_file):
+        script_dir = os.path.dirname(os.path.abspath(__file__))
+        candidates = [
+            os.path.join(script_dir, maint_file),
+            "MAINTAINERS.md",
+            os.path.join(script_dir, "..", "MAINTAINERS.md"),
+        ]
+        for candidate in candidates:
+            if os.path.exists(candidate):
+                maint_file = candidate
+                break
     with open(maint_file) as f:
         m = f.read().splitlines()
     para, repos = parse(m)
@@ -94,9 +130,14 @@ def parse_maintainers(repo=None):
 
 def main_repo(args):
     repos, paragraph = parse_maintainers(args.repo)
-    for (repo_name, maintainers) in repos:
-        repo_url = f"git@github.com:flatcar/{repo_name}"
-        subprocess.run(["git", "clone", "--depth=1", repo_url])
+    for repo_name, maintainers in repos:
+        if args.dry_run:
+            print(
+                f"[DRY-RUN] Would clone repo {repo_name}, checkout {BRANCH_NAME}, "
+                f"write MAINTAINERS.md, commit, and push"
+            )
+            continue
+        clone_repo(repo_name)
         checkout_branch(repo_name)
         write_maintainers_file(repo_name, paragraph, maintainers)
         commit(repo_name)
@@ -108,71 +149,100 @@ def prepare_req(repo, token, api):
     url = f"https://api.github.com/repos/flatcar/{repo}{api}"
     headers = {
         "Accept": "application/vnd.github+json",
-        f"Authorization": "Bearer {token}",
+        "Authorization": f"Bearer {token}",
     }
     return url, headers
 
 
-def get_pr(repo, token):
+def get_pr(repo, token, session=None):
+    if session is None:
+        session = get_session()
     url, headers = prepare_req(repo, token, "pulls")
     params = {"state": "open", "head": f"flatcar:{BRANCH_NAME}"}
-    return requests.get(url, headers=headers, params=params)
+    return session.get(url, headers=headers, params=params)
 
 
-def get_default_branch(repo, token):
+def get_default_branch(repo, token, session=None):
+    if session is None:
+        session = get_session()
     url, headers = prepare_req(repo, token, "")
-    resp = requests.get(url, headers=headers).json()
+    resp = session.get(url, headers=headers).json()
     return resp["default_branch"]
 
 
-def create_pr(repo, token, base):
+def create_pr(repo, token, base, session=None):
+    if session is None:
+        session = get_session()
     url, headers = prepare_req(repo, token, "pulls")
     data = {
         "title": "Sync MAINTAINERS.md",
         "head": f"flatcar:{BRANCH_NAME}",
         "base": base,
     }
-    return requests.post(url, headers=headers, json=data)
+    return session.post(url, headers=headers, json=data)
 
 
-def update_assignees(repo, token, pr, assignees):
+def update_assignees(repo, token, pr, assignees, session=None):
+    if session is None:
+        session = get_session()
     url, headers = prepare_req(repo, token, f"pulls/{pr}/requested_reviewers")
     data = {"reviewers": assignees}
-    return requests.post(url, headers=headers, json=data)
+    return session.post(url, headers=headers, json=data)
 
 
 def get_assignees(maintainers):
-    assignees = [e.split("@")[1] for e in maintainers]
+    assignees = []
+    for e in maintainers:
+        if "@" in e:
+            handle = e.split("@")[1].split("]")[0].strip()
+            if handle:
+                assignees.append(handle)
     return assignees
 
 
 def main_github(args):
     token = os.getenv("GITHUB_TOKEN")
-    if not token:
+    if not token and not args.dry_run:
         raise Exception("Missing GITHUB_TOKEN env variable")
+    if not token:
+        token = "dry_run_token"
     repos, _ = parse_maintainers(args.repo)
-    for (repo_name, maintainers) in repos:
-        pr = get_pr(repo_name, token).json()
+    session = None
+    for repo_name, maintainers in repos:
+        assignees = get_assignees(maintainers)
+        if args.dry_run:
+            print(
+                f"[DRY-RUN] Would check/create PR for {repo_name} and request reviewers: {assignees}"
+            )
+            continue
+        if session is None:
+            session = get_session()
+        pr_resp = get_pr(repo_name, token, session=session)
+        pr = pr_resp.json()
         if not pr:
             print(f"{repo_name} creating pr")
-            base = get_default_branch(repo_name, token)
-            pr = [create_pr(repo_name, token, base).json()]
+            base = get_default_branch(repo_name, token, session=session)
+            pr = [create_pr(repo_name, token, base, session=session).json()]
         prnum = pr[0]["number"]
-        assignees = get_assignees(maintainers)
-        resp = update_assignees(repo_name, token, prnum, assignees)
+        resp = update_assignees(repo_name, token, prnum, assignees, session=session)
         if resp.status_code != 201:
             print(resp.json())
         else:
-            print("{repo_name} ok")
+            print(f"{repo_name} ok")
 
 
 def main_list(args):
     repos, _ = parse_maintainers()
-    for (repo_name, _) in repos:
+    for repo_name, _ in repos:
         print(repo_name)
 
 
 parser = argparse.ArgumentParser(prog="sync-maintainers.py")
+parser.add_argument(
+    "--dry-run",
+    action="store_true",
+    help="Preview actions without modifying git repositories or sending GitHub REST API POST requests",
+)
 subparser = parser.add_subparsers(required=True, dest="cmd")
 parser_repo = subparser.add_parser("repo", help="perform git repository operations")
 parser_repo.add_argument("--repo", help="Repository to operate on; default all")

--- a/sync-maintainers/test_sync_maintainers.py
+++ b/sync-maintainers/test_sync_maintainers.py
@@ -1,0 +1,138 @@
+import importlib.util
+import os
+import sys
+import unittest
+from unittest.mock import MagicMock, call, mock_open, patch
+
+# Add sync-maintainers directory to sys.path
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+spec = importlib.util.spec_from_file_location(
+    "sync_maintainers",
+    os.path.join(os.path.dirname(os.path.abspath(__file__)), "sync-maintainers.py"),
+)
+sync = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(sync)
+
+
+class TestSyncMaintainers(unittest.TestCase):
+
+    def test_parse(self):
+        sample_lines = [
+            "# Maintainers",
+            "General governance paragraph line 1.",
+            "General governance paragraph line 2.",
+            "### nebraska",
+            "maintainers:",
+            "* [@t-lo](https://github.com/t-lo)",
+            "* [@pothos](https://github.com/pothos)",
+            "### Flatcar",
+            "maintainers:",
+            "* [@chewi](https://github.com/chewi)",
+        ]
+        para, repos = sync.parse(sample_lines)
+        self.assertEqual(
+            para,
+            [
+                "General governance paragraph line 1.",
+                "General governance paragraph line 2.",
+            ],
+        )
+        self.assertEqual(len(repos), 1)
+        self.assertEqual(repos[0][0], "nebraska")
+        self.assertEqual(
+            repos[0][1],
+            [
+                "* [@t-lo](https://github.com/t-lo)",
+                "* [@pothos](https://github.com/pothos)",
+            ],
+        )
+
+    @patch(
+        "builtins.open",
+        new_callable=mock_open,
+        read_data="# Maintainers\nIntro text\n### repo1\nmaintainers:\n* [@user1](https://github.com/user1)\n",
+    )
+    def test_parse_maintainers(self, mock_file):
+        repos, paragraph = sync.parse_maintainers(maint_file="dummy_MAINTAINERS.md")
+        self.assertEqual(paragraph, "Intro text")
+        self.assertEqual(len(repos), 1)
+        self.assertEqual(repos[0][0], "repo1")
+
+    def test_prepare_req_header_formatting(self):
+        url, headers = sync.prepare_req("nebraska", "my-secret-token", "pulls")
+        self.assertEqual(url, "https://api.github.com/repos/flatcar/nebraska/pulls")
+        self.assertEqual(headers["Authorization"], "Bearer my-secret-token")
+        self.assertNotIn("{token}", headers["Authorization"])
+
+    def test_get_assignees(self):
+        maintainers = [
+            "* [@t-lo](https://github.com/t-lo)",
+            "* [@pothos](https://github.com/pothos)",
+        ]
+        assignees = sync.get_assignees(maintainers)
+        self.assertEqual(assignees, ["t-lo", "pothos"])
+
+    @patch("subprocess.run")
+    def test_clone_repo_ssh_success(self, mock_run):
+        mock_run.return_value = MagicMock(returncode=0)
+        sync.clone_repo("nebraska")
+        mock_run.assert_called_once_with(
+            ["git", "clone", "--depth=1", "git@github.com:flatcar/nebraska"], check=True
+        )
+
+    @patch("subprocess.run")
+    def test_clone_repo_ssh_fail_https_fallback(self, mock_run):
+        import subprocess
+
+        def run_side_effect(cmd, check=True):
+            if "git@github.com" in cmd[3]:
+                raise subprocess.CalledProcessError(1, cmd)
+            return MagicMock(returncode=0)
+
+        mock_run.side_effect = run_side_effect
+        sync.clone_repo("nebraska")
+        self.assertEqual(mock_run.call_count, 2)
+        mock_run.assert_has_calls(
+            [
+                call(
+                    ["git", "clone", "--depth=1", "git@github.com:flatcar/nebraska"],
+                    check=True,
+                ),
+                call(
+                    [
+                        "git",
+                        "clone",
+                        "--depth=1",
+                        "https://github.com/flatcar/nebraska.git",
+                    ],
+                    check=True,
+                ),
+            ]
+        )
+
+    @patch.object(sync, "parse_maintainers")
+    @patch("subprocess.run")
+    def test_dry_run_repo(self, mock_subproc, mock_parse):
+        mock_parse.return_value = (
+            [("nebraska", ["* [@t-lo](https://github.com/t-lo)"])],
+            "para",
+        )
+        args = MagicMock(dry_run=True, repo="nebraska")
+        sync.main_repo(args)
+        mock_subproc.assert_not_called()
+
+    @patch.object(sync, "parse_maintainers")
+    @patch.object(sync, "get_session")
+    def test_dry_run_github(self, mock_get_session, mock_parse):
+        mock_parse.return_value = (
+            [("nebraska", ["* [@t-lo](https://github.com/t-lo)"])],
+            "para",
+        )
+        args = MagicMock(dry_run=True, repo="nebraska")
+        sync.main_github(args)
+        mock_get_session.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes #2264

## Summary

This PR refactors and hardens the maintainer synchronization tooling in `sync-maintainers/sync-maintainers.py`.

## Why Proposing the Change

The `sync-maintainers.py` script had string formatting bugs preventing headers and output from rendering variables correctly, lacked dry-run capabilities to safely test sync operations without mutating remote repos or firing API calls, lacked GitHub REST API retry handling for rate limits / 5xx errors, and hardcoded SSH clone URLs without falling back to HTTPS when SSH keys are not configured.

## Overview of Changes

- **Fixed F-String Formatting**:
  - Corrected header construction: `"Authorization": f"Bearer {token}"`.
  - Fixed output formatting: `print(f"{repo_name} ok")`.
- **Dry-Run Flag (`--dry-run`)**:
  - Added CLI flag `--dry-run` to preview git operations and PR creation/reviewer assignments without making git pushes or API `POST` requests.
- **GitHub API Retries**:
  - Integrated `requests.Session` with `HTTPAdapter` and `urllib3.util.retry.Retry` configured for exponential backoff (retrying 429, 500, 502, 503, 504).
- **Git SSH Fallback to HTTPS**:
  - Added error handling on `git clone` so that if SSH clone fails, the script seamlessly falls back to HTTPS clone.
- **Unit Testing**:
  - Added `sync-maintainers/test_sync_maintainers.py` with unit tests using `unittest.mock` for parsing, header formatting, dry-run flags, assignees extraction, and HTTPS fallback logic.
- **CI Workflow**:
  - Created `.github/workflows/sync-maintainers-test.yml` to execute unit tests automatically in CI.

## Verification

- Ran unit test suite locally: `python3 -m unittest discover -s sync-maintainers -v` (All 8 tests passing).
- Tested `--dry-run` flag with both `repo` and `github` subcommands.
- Verified DCO commit sign-off (`Signed-off-by`).