### PR TITLE
docs: fix malformed Cluster API table rows in interop-matrix.md

### DIFF
--- a/interop-matrix.md
+++ b/interop-matrix.md
@@ -51,9 +51,9 @@ Please propose ownership by filing a PR for this document.
 | CAPA        |              X                 |   X   |  X (upstream) | Upstream |                      | Covered by CAPA release tests |
 | CAPA EKS    |                                |       |             | [no owner] |                      |       |
 | CAPZ        |                                |   w/ caveat |       | @flatcar/flatcar-maintainers |  | WIP Prototype |
-| CAPV        |                                | [no owner] |        |                                   |       |
-| CAPM3       |                                | [no owner] |        |                                   |       |
-| CAPG        |                                | [no owner] |        |                                   |       |
+| CAPV        |                                |       |             | [no owner] |                      |       |
+| CAPM3       |                                |       |             | [no owner] |                      |       |
+| CAPG        |                                |       |             | [no owner] |                      |       |
 | CAPO        |                                |   X   |  X (upstream) | Upstream |                      |       |
 
 ## Kubernetes Distros


### PR DESCRIPTION
### Why

The Cluster API table in `interop-matrix.md` has a 7-column header (Environment | Full-Feature | Works | Tested (CI) | Owner | Reference | Notes), but the CAPV, CAPM3, and CAPG rows only had 6 columns. This shifted `[no owner]` into the `Works` column instead of `Owner`, and dropped the trailing `Notes` column entirely. Every other row in the table (CAPB, CAPA, CAPA EKS, CAPZ, CAPO) has the full 7 columns.

### What changed

- Realigned the CAPV, CAPM3, and CAPG rows to match the table's   7-column structure, using the CAPA EKS row as the formatting   template (empty Full-Feature/Works/Tested(CI), `[no owner]` in the Owner column, empty Reference/Notes).

### Notes / open questions

- This only fixes the table structure/alignment. It does not fill in  real `Full-Feature`, `Tested (CI)`, or `Reference` values for
  CAPV/CAPM3/CAPG, or assign real owners  that's a separate   maintainer/PR-author call outside the scope of this formatting fix.
