### PR TITLE
docs: fix Flatcar issue tracker URL casing in SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -25,5 +25,5 @@ Every day look into upstream security trackers like below:
 - Golang announce mailing list
 - Rust security announcements
 - (optional) issue trackers of other distros
-- Whenever we discover any new CVE, we add it to an internal database, and use automation tools to create a new issue about the CVE in [Flatcar GitHub issues](https://github.com/Flatcar/Flatcar/issues) with labels `security` and `advisory`.
-- If an issue for updating the specific package affected by the new CVE is already open in [Flatcar GitHub issues](https://github.com/Flatcar/Flatcar/issues), then unfortunately we need to manually edit the existing issue to add the new CVE.
+- Whenever we discover any new CVE, we add it to an internal database, and use automation tools to create a new issue about the CVE in [Flatcar GitHub issues](https://github.com/flatcar/Flatcar/issues) with labels `security` and `advisory`.
+- If an issue for updating the specific package affected by the new CVE is already open in [Flatcar GitHub issues](https://github.com/flatcar/Flatcar/issues), then unfortunately we need to manually edit the existing issue to add the new CVE.


### PR DESCRIPTION
## Summary
- Correct issue tracker links in `SECURITY.md` from `github.com/Flatcar/Flatcar` to `github.com/flatcar/Flatcar` to match the rest of the project docs

## Test plan
- [ ] Both security runbook links open the central Flatcar issue tracker
- [ ] No other content in `SECURITY.md` was changed