### PR TITLE
docs: fix case-sensitive filename in CODE_OF_CONDUCT.md link

### DIFF
--- a/governance.md
+++ b/governance.md
@@ -157,7 +157,7 @@ for that purpose.
 
 ## Code of Conduct
 
-[Code of Conduct](./code-of-conduct.md)
+[Code of Conduct](./CODE_OF_CONDUCT.md)
 violations by community members will be discussed and resolved
 on the [private Maintainer mailing list](mailto:maintainers@flatcar-linux.org).  If a Maintainer is directly involved
 in the report, the Maintainers will instead designate two Maintainers to work


### PR DESCRIPTION
Line 160 of `governance.md` contains a relative link pointing to
`./code-of-conduct.md` (lowercase), but the actual file in the
repository is `CODE_OF_CONDUCT.md` (uppercase). On case-sensitive
filesystems (Linux) and in GitHub's raw markdown renderer, this
resolves as a broken link — clicking it returns a 404.

Update the reference to match the exact filename casing.
No content, wording, or surrounding context has been changed —
this is a pure link target correction.

## How to verify

Open `governance.md` on GitHub after the PR merges and navigate to
line 160. Confirm that "Code of Conduct" now renders as a clickable
hyperlink that resolves correctly to `CODE_OF_CONDUCT.md`:
https://github.com/flatcar/Flatcar/blob/main/CODE_OF_CONDUCT.md

## Testing done

Verified the actual filename casing in the repository root and
confirmed the mismatch with the following commands:

$ ls | grep -i code
CODE_OF_CONDUCT.md

$ grep -n "code-of-conduct" governance.md
160: [Code of Conduct](./code-of-conduct.md)

Output confirms the link target uses lowercase while the actual
file is uppercase, causing a broken reference on Linux filesystems.