### PR TITLE
docs: fix incorrect org casing in GitHub URLs in SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -25,5 +25,5 @@ Every day look into upstream security trackers like below:
 - Golang announce mailing list
 - Rust security announcements
 - (optional) issue trackers of other distros
-- Whenever we discover any new CVE, we add it to an internal database, and use automation tools to create a new issue about the CVE in [Flatcar GitHub issues](https://github.com/Flatcar/Flatcar/issues) with labels `security` and `advisory`.
-- If an issue for updating the specific package affected by the new CVE is already open in [Flatcar GitHub issues](https://github.com/Flatcar/Flatcar/issues), then unfortunately we need to manually edit the existing issue to add the new CVE.
+- Whenever we discover any new CVE, we add it to an internal database, and use automation tools to create a new issue about the CVE in [Flatcar GitHub issues](https://github.com/flatcar/Flatcar/issues) with labels `security` and `advisory`.
+- If an issue for updating the specific package affected by the new CVE is already open in [Flatcar GitHub issues](https://github.com/flatcar/Flatcar/issues), then unfortunately we need to manually edit the existing issue to add the new CVE.


### PR DESCRIPTION
Lines 28 and 29 of `SECURITY.md` link to the Flatcar issue tracker
using an incorrectly cased org name — `github.com/Flatcar/Flatcar`
instead of the correct `github.com/flatcar/Flatcar`. GitHub org
names are case-sensitive and the Flatcar org uses all lowercase.
While GitHub currently redirects the uppercase variant, the source
should reference the canonical URL to avoid any future breakage.

No content, wording, or structure has been changed — only the
org name casing in both URLs.

## How to verify

Open both corrected URLs and confirm they resolve to the Flatcar
issue tracker without any redirects:
https://github.com/flatcar/Flatcar/issues

## Testing done

Confirmed both incorrect occurrences before the fix:

$ grep -n "Flatcar/Flatcar" SECURITY.md
28: https://github.com/Flatcar/Flatcar/issues
29: https://github.com/Flatcar/Flatcar/issues

Output confirms exactly two instances, both corrected in this patch.