### PR TITLE
docs: fix typos, grammar, capitalization and link syntax across documentation files

### DIFF
--- a/CIS/level1-remediation_notes-2020-12-08.md
+++ b/CIS/level1-remediation_notes-2020-12-08.md
@@ -162,7 +162,7 @@ password user1 password1
 * sysctl (currently there is a bug for persistence of these settings https://github.com/kinvolk/Flatcar/issues/297)
   * IP forwarding
 
-```sysclt
+```sysctl
 # /etc/sysctl.d/forward.conf
 net.ipv4.ip_forward=0
 ```

--- a/attic/community-meetings/2021-05-11.md
+++ b/attic/community-meetings/2021-05-11.md
@@ -64,7 +64,7 @@ The meeting largely followed the [slide deck](2021-05-11-slides.pdf). After the 
 - Q: **What's the relationship between ClusterAPI and Lokomotive?**
 - Iago: Currently, no direct relation. We plan to investigate using parts of CAPI in the future, e.g. provisioning, but we do not plan to support the full-blown management / workload clusters pattern at this time.
 
-- Q: **here seems to be a lack of bare metal deployments / supported platforms in the compatibility matrix - is this intentional? Do we exepct Flatcar to "just work" since it's using Linux? Is there potential to add bare metal platforms (we use / plan to use Flatcar primarily on bare metal)?**
+- Q: **here seems to be a lack of bare metal deployments / supported platforms in the compatibility matrix - is this intentional? Do we expect Flatcar to "just work" since it's using Linux? Is there potential to add bare metal platforms (we use / plan to use Flatcar primarily on bare metal)?**
 - Thilo: It's Linux, as long as it PXE boots, you should be fine.
 - Andy: Are we discussing a hardware compatibility list?
 - Jannik: Not quite, however since we'll be running on bare metal we'll also test our bare metal. We're willing to support the community for our use cases.

--- a/governance.md
+++ b/governance.md
@@ -2,7 +2,7 @@
 
 
 Flatcar is a community based project, anyone who wants to participate is welcomed.
-We adopted the [CNCF code of Conduct](./CODE_OF_CONDUCT.md) as we pledge to be an opening and welcoming community for anyone who want to participate in it.
+We adopted the [CNCF Code of Conduct](./CODE_OF_CONDUCT.md) as we pledge to be an open and welcoming community for anyone who wants to participate in it.
 
 The project is governed by a flat hierarchy - a group of people sharing a common vision of Flatcar in accordance to its mission statement.
 
@@ -44,10 +44,10 @@ The Flatcar project, its leadership, and its maintainers embrace the following v
 
 ## Maintainers
 
-Flatcar Maintainers have full access to most of the repositories in the [Flatcar project](https://github.com/orgs/flatcar/), except for very few repositories that contain sensitive information, e.g. for with undisclosed security issues (see [SECURITY.md](./SECURITY.md) for more information).
+Flatcar Maintainers have full access to most of the repositories in the [Flatcar project](https://github.com/orgs/flatcar/), except for very few repositories that contain sensitive information, e.g. those with undisclosed security issues (see [SECURITY.md](./SECURITY.md) for more information).
 Maintainers can merge PRs, approve PR builds+tests, and create and publish releases.
 Maintainers collectively manage the project's resources, interact with contributors, elect new maintainers, and remove inactive ones.
-The current list of maintainers can be found in [MAINTAINERS.md](./MAINTAINERS.md). Most maintainer access privileges are granted via membership of the Flatcar Github organisation's [Flatcar Maintainers team](https://github.com/orgs/flatcar/teams/flatcar-maintainers).
+The current list of maintainers can be found in [MAINTAINERS.md](./MAINTAINERS.md). Most maintainer access privileges are granted via membership of the Flatcar GitHub organisation's [Flatcar Maintainers team](https://github.com/orgs/flatcar/teams/flatcar-maintainers).
 
 This privilege is granted with some expectation of responsibility: maintainers
 are people who care about the Flatcar project and want to help it grow and
@@ -104,7 +104,7 @@ The nominating maintainer will create a PR to update the Maintainers List.
 It is recommended to describe the reasons for the nomination and the contribution of the nominee in the PR.
 Upon consensus of incumbent maintainers, the PR will be approved and the new maintainer becomes active.
 
-Maintainers who are selected will be granted the necessary GitHub rights. The (CONTRIBUTING.md)[https://github.com/flatcar/Flatcar/blob/main/CONTRIBUTING.md] process should be used when onboarding a new maintainer.
+Maintainers who are selected will be granted the necessary GitHub rights. The [CONTRIBUTING.md](https://github.com/flatcar/Flatcar/blob/main/CONTRIBUTING.md) process should be used when onboarding a new maintainer.
 
 
 ### Removing a Maintainer


### PR DESCRIPTION
##Description

**What changes has been done**

### 1. `governance.md`
- Line 5: Fixed capitalization and grammar: "code of Conduct" -> "Code of Conduct", "opening and welcoming" -> "open and welcoming", and "anyone who want" -> "anyone who wants".
- Line 47: Fixed grammar: "...e.g. for with undisclosed..." -> "...e.g. those with undisclosed...".
- Line 50: Standardized "Github" -> "GitHub".
- Line 107: Fixed a broken/reversed Markdown link syntax typo: (CONTRIBUTING.md)[https://...] -> [CONTRIBUTING.md](https://...).

### 2. `attic/community-meetings/2021-05-11.md`
* **Typo fix**: Corrected `exepct` to `expect` in the Q&A section (Line 67).

### 3. `CIS/level1-remediation_notes-2020-12-08.md`
* **Code block correction**: Fixed the syntax highlighting language specifier typo `sysclt` to `sysctl` (Line 165).
