### PR TITLE
fix(sync-maintainers): interpolate GitHub token in Authorization header

### DIFF
--- a/sync-maintainers/sync-maintainers.py
+++ b/sync-maintainers/sync-maintainers.py
@@ -108,7 +108,10 @@ def prepare_req(repo, token, api):
     url = f"https://api.github.com/repos/flatcar/{repo}{api}"
     headers = {
         "Accept": "application/vnd.github+json",
-        f"Authorization": "Bearer {token}",
+        # Value must be an f-string so the token is interpolated.
+        # Using f"Authorization" as the key left the value as the literal
+        # "Bearer {token}", which makes every GitHub API call return 401.
+        "Authorization": f"Bearer {token}",
     }
     return url, headers
 


### PR DESCRIPTION
## Summary

This PR fixes a bug in `sync-maintainers/sync-maintainers.py` where the GitHub API `Authorization` header never received the real token value. Every call made by the `github` subcommand (list/create PRs, request reviewers) authenticated with the literal string `Bearer {token}` instead of the contents of `GITHUB_TOKEN`, which causes GitHub to reject the requests with **401 Unauthorized**.

## Problem

`prepare_req()` builds the headers used by all GitHub API helpers (`get_pr`, `get_default_branch`, `create_pr`, `update_assignees`). The previous code was:

```python
headers = {
    "Accept": "application/vnd.github+json",
    f"Authorization": "Bearer {token}",
}
```

Two easy-to-miss details:

1. The f-string was on the dict key (`f"Authorization"`), which has no `{...}` placeholders, so it evaluates to plain `"Authorization"` and does nothing useful.
2. The value was a normal string: `"Bearer {token}"`. Because it is not an f-string, Python does not interpolate `token`. The header sent on the wire is literally:

Authorization: Bearer {token}


So even when `GITHUB_TOKEN` is set correctly in the environment, API calls fail authentication.

## Impact

- `./sync-maintainers.py github` (and `--repo=...`) cannot create sync PRs or request reviewers.
- Maintainers may believe the token or permissions are wrong, when the bug is in header construction.
- This blocks the GitHub half of the maintainer-sync workflow after local git ops succeed.

## Fix

Use a normal key and an f-string for the value:

```python
headers = {
    "Accept": "application/vnd.github+json",
    "Authorization": f"Bearer {token}",
}
```

Comments in code document why, so this does not regress.

## Relation to #2227 / #2228

- #2227 / #2228 fix the parser so repos are discovered again after the `MAINTAINERS.md` table rewrite.
- This PR is independent and complementary: even with a working parser, the `github` path still 401s until the Authorization header interpolates the token.
- I confirmed the auth bug is still present on the #2228 branch as well; this change can land before or after that PR.

## Scope

- In scope: `prepare_req()` Authorization header construction only.
- Out of scope: parser rewrite for subgroup tables (covered by #2228), broader refactor of `sync-maintainers`, or workflow/CI changes.

## How to verify

1. Inspect the diff: value is `f"Bearer {token}"`, not a plain `"Bearer {token}"`.
2. Optional runtime check (with a valid token and after repos are discoverable):

```bash
   cd sync-maintainers
   export GITHUB_TOKEN=ghp_...   # or a fine-grained token with PR access
   ./sync-maintainers.py github --repo=nebraska
```

   - Before: GitHub responds 401 / auth error payloads.
   - After: request is authenticated (success or a non-auth error such as permissions/branch state).

3. No changelog / image CI needed — tooling-only change in the meta repo.

## Test plan

- Confirmed broken pattern: non-f-string value leaves `{token}` unsubstituted
- Confirmed fixed pattern: `f"Bearer {token}"` interpolates `GITHUB_TOKEN`
- Maintainer smoke-test of `github` subcommand against one Flatcar org repo (optional)