### PR TITLE
fix: correct PST to PDT timezone and normalize GitHub URL casing

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -25,5 +25,5 @@ Every day look into upstream security trackers like below:
 - Golang announce mailing list
 - Rust security announcements
 - (optional) issue trackers of other distros
-- Whenever we discover any new CVE, we add it to an internal database, and use automation tools to create a new issue about the CVE in [Flatcar GitHub issues](https://github.com/Flatcar/Flatcar/issues) with labels `security` and `advisory`.
-- If an issue for updating the specific package affected by the new CVE is already open in [Flatcar GitHub issues](https://github.com/Flatcar/Flatcar/issues), then unfortunately we need to manually edit the existing issue to add the new CVE.
+- Whenever we discover any new CVE, we add it to an internal database, and use automation tools to create a new issue about the CVE in [Flatcar GitHub issues](https://github.com/flatcar/Flatcar/issues) with labels `security` and `advisory`.
+- If an issue for updating the specific package affected by the new CVE is already open in [Flatcar GitHub issues](https://github.com/flatcar/Flatcar/issues), then unfortunately we need to manually edit the existing issue to add the new CVE.

--- a/governance.md
+++ b/governance.md
@@ -134,7 +134,7 @@ and can be rapidly returned to Maintainer status if their availability changes.
 Time zones permitting, Maintainers are expected to participate in the Flatcar Developer Syncs meeting every 4th Wednesday of a month.
 The meeting time observes the Universal Coordinated time. It occurs at 2:30pm UTC.
 Depending on your local timezone, the slot might be subject to summer time changes.
-* During daylight saving time, the meeting occurs at 8pm IST (IST does not observe daylight saving time) / 4:30pm CEST / 10:30am EDT / 7:30am PST.
+* During daylight saving time, the meeting occurs at 8pm IST (IST does not observe daylight saving time) / 4:30pm CEST / 10:30am EDT / 7:30am PDT.
 * Outside of daylight saving time, the meeting occurs at 8pm IST  / 3:30pm CET / 9:30am EST / 6:30am PST.
 
 A calendar is available to ease planning. The calendar contains Developer syncs, project office hours, and one-off events like bug fixing or doc writing days.


### PR DESCRIPTION
During daylight saving time, the US Pacific timezone is PDT (UTC-7), not PST (UTC-8). The meeting time listed in governance.md was correct in hours (7:30am) but used the wrong timezone label. Additionally, SECURITY.md used a capitalised GitHub org URL which is inconsistent with the rest of the repository.