### PR TITLE
docs: remove dead kinvolk/flatcar-linux project board links in attic …

### DIFF
--- a/attic/community-meetings/2021-07-13.md
+++ b/attic/community-meetings/2021-07-13.md
@@ -40,7 +40,7 @@
     - Big test run right before a release may uncover issues not found during development 
     - Each release is signed and gets uploaded to our website and all supported cloud providers 
     - Release planning happens every two weeks: review pending PRs and see if they can be fast tracked into the release 
-      - Release planning board has been made public today (https://github.com/orgs/kinvolk/projects/15) 😊 Community input is welcome! 
+      - Release planning board has been made public today (archived, link no longer available) 😊 Community input is welcome! 
     - Build/Test:
       - New SDK is produced on alpha release 
       - Update signature is always cryptographically verified 
@@ -59,7 +59,7 @@
 5.  Sayan talks about recent releases: 
     - Alpha 2920.0.0, Beta 2905.1.0 
     - There will be monthly community call for release planning and a smaller bi-weekly to check progress
-    - Sayan introduces the planning board (https://github.com/orgs/kinvolk/projects/15)  
+    - Sayan introduces the planning board (archived, link no longer available)  
     - Columns for planned/in-progress/ready-for-review and items-completed for the closest update of alpha (and bumps of the other release channels). 
 
 ## Q&A

--- a/attic/community-meetings/2021-07-26.md
+++ b/attic/community-meetings/2021-07-26.md
@@ -3,7 +3,7 @@
 ## Links for participants
 - Call (for actively participating): [https://zoom.us/j/99741357880](https://zoom.us/j/99741357880)
 - Youtube live stream link (for passively watching): https://www.youtube.com/watch?v=SM4lfaITzsI
-- Release Planning Board: [https://github.com/orgs/kinvolk/projects/15](https://github.com/orgs/kinvolk/projects/15)
+- Release Planning Board (archived, link no longer available)
 
 ## Welcome
 - Brief introduction of new participants or attendees

--- a/attic/community-meetings/2021-08-23.md
+++ b/attic/community-meetings/2021-08-23.md
@@ -3,7 +3,7 @@
 ## Links for participants
 - Call (for actively participating): [https://us06web.zoom.us/j/85781192057](https://us06web.zoom.us/j/85781192057)
 - Youtube live stream link (for passively watching): http://www.youtube.com/watch?v=TfmiNy5020g
-- Release Planning Board: [https://github.com/orgs/kinvolk/projects/15](https://github.com/orgs/kinvolk/projects/15)
+- Release Planning Board (archived, link no longer available)
 
 ## Welcome
 - Brief introduction of new participants or attendees

--- a/attic/community-meetings/2021-09-28.md
+++ b/attic/community-meetings/2021-09-28.md
@@ -5,7 +5,7 @@
   * Meeting ID: 843 3611 6610
   * Passcode: 444888
 - Youtube live stream / recording: [https://www.youtube.com/watch?v=XbkHZMJlC8g](https://www.youtube.com/watch?v=XbkHZMJlC8g)
-- Release Planning Board: [https://github.com/orgs/flatcar-linux/projects/5](https://github.com/orgs/flatcar-linux/projects/5)
+- Release Planning Board (archived, link no longer available)
 
 ## Welcome
 - Brief introduction of new participants or attendees

--- a/attic/community-meetings/2021-10-26.md
+++ b/attic/community-meetings/2021-10-26.md
@@ -5,7 +5,7 @@
   - Meeting ID: 820 5424 0491
   - Passcode: 444888
 - Youtube live stream / recording: [https://www.youtube.com/watch?v=xh-MkIoZvVw](https://www.youtube.com/watch?v=xh-MkIoZvVw)
-- Release Planning Board: [https://github.com/orgs/flatcar-linux/projects/5](https://github.com/orgs/flatcar-linux/projects/5)
+- Release Planning Board (archived, link no longer available)
 
 ## Welcome
 - Brief introduction of new participants or attendees

--- a/attic/community-meetings/2021-11-23.md
+++ b/attic/community-meetings/2021-11-23.md
@@ -5,7 +5,7 @@
   - Meeting ID: 820 5424 0491
   - Passcode: 444888
 - Youtube live stream / recording: [https://www.youtube.com/watch?v=VUzMuZgFQfY](https://www.youtube.com/watch?v=VUzMuZgFQfY)
-- Release Planning Board: [https://github.com/orgs/flatcar-linux/projects/5](https://github.com/orgs/flatcar-linux/projects/5)
+- Release Planning Board (archived, link no longer available)
 
 ## Welcome
 - Brief introduction of new participants or attendees

--- a/attic/community-meetings/2022-01-11.md
+++ b/attic/community-meetings/2022-01-11.md
@@ -22,7 +22,7 @@
 - Fleetlock (@aniruddha2000, @tormath1 )
 
 ## Release planning
-- Ongoing and upcoming releases (https://github.com/orgs/flatcar-linux/projects/5)
+- Ongoing and upcoming releases (archived, link no longer available)
 
 ## Q&A
 - Questions from community participants, answered by the Flatcar maintainers 


### PR DESCRIPTION
Fixes #2297.

Removed broken project board links that returned 404 (kinvolk and flatcar-linux orgs) in historic community meeting notes under `attic/community-meetings/`. The URLs were removed and converted to plain text indicating the links are no longer available since the project boards are permanently gone.

Changed files:
- attic/community-meetings/2021-07-13.md
- attic/community-meetings/2021-07-26.md
- attic/community-meetings/2021-08-23.md
- attic/community-meetings/2021-09-28.md
- attic/community-meetings/2021-10-26.md
- attic/community-meetings/2021-11-23.md
- attic/community-meetings/2022-01-11.md
