### PR TITLE
docs: README.md Code of Conduct contact is outdated, disagrees with CODE_OF_CONDUCT.md

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -2,4 +2,4 @@
 
 We follow the [CNCF Code of Conduct](https://github.com/cncf/foundation/blob/main/code-of-conduct.md).
 
-Please contact [private Maintainer mailing list](mailto:maintainers@flatcar-linux.org) or the Cloud Native Computing Foundation mediator, conduct@cncf.io, to report an issue.
+Please contact the [private Maintainer mailing list](mailto:maintainers@flatcar-linux.org) or the [CNCF Code of Conduct Committee](https://www.cncf.io/conduct/committee/), conduct@cncf.io, to report an issue.

--- a/README.md
+++ b/README.md
@@ -219,7 +219,7 @@ For full details see our [governance document](governance.md).
 
 We follow the [CNCF Code of Conduct](https://github.com/cncf/foundation/blob/main/code-of-conduct.md).
 
-Please contact the [private Maintainer mailing list](mailto:maintainers@flatcar-linux.org) or the Linux Foundation mediator, Mishi Choudhary ([mishi@linux.com](mailto:mishi@linux.com)), to report an issue.
+Please contact the [private Maintainer mailing list](mailto:maintainers@flatcar-linux.org) or the Cloud Native Computing Foundation mediator, conduct@cncf.io, to report an issue.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -219,7 +219,7 @@ For full details see our [governance document](governance.md).
 
 We follow the [CNCF Code of Conduct](https://github.com/cncf/foundation/blob/main/code-of-conduct.md).
 
-Please contact the [private Maintainer mailing list](mailto:maintainers@flatcar-linux.org) or the Cloud Native Computing Foundation mediator, conduct@cncf.io, to report an issue.
+Please contact the [private Maintainer mailing list](mailto:maintainers@flatcar-linux.org) or the [CNCF Code of Conduct Committee](https://www.cncf.io/conduct/committee/), conduct@cncf.io, to report an issue.
 
 ---
 


### PR DESCRIPTION
## Why

README.md and CODE_OF_CONDUCT.md both describe who to contact to report a Code of Conduct violation, and they disagree. 

CODE_OF_CONDUCT.md was updated in 2023 (commit 3e2ba40, "use CNCF conduct email") to point to the CNCF's own conduct mediator instead of naming a specific Linux Foundation individual. README.md's Code of Conduct section was never updated to match, so it still tells readers to contact a mediator and email address the project stopped using two years ago.

## What changed

Updated the mediator contact in README.md's Code of Conduct section to match CODE_OF_CONDUCT.md  now both files point to the Cloud Native. Computing Foundation mediator (conduct@cncf.io) instead of the outdated Linux Foundation contact.

## Notes

None outstanding. Single-line change, no headings or TOC entries touched.
