### PR TITLE
docs: fix Kubematic typo in interop matrix 

### DIFF
--- a/interop-matrix.md
+++ b/interop-matrix.md
@@ -68,7 +68,7 @@ Please propose ownership by filing a PR for this document.
 | K3s |                                        |   X   |             | [no owner] |                      |       |
 | EKS-Distro |                                 |   X   |             | [no owner] |                      |       |
 | KOPS |                                       |   X   |             | upstream |                        |       |
-| Kubematic |                                  |   X   |             | [no owner] |                      |       |
+| Kubermatic |                                  |   X   |             | [no owner] |                      |       |
 | Gardener |                                   |   X   |             | [no owner] |                      |       |
 
 ## Other


### PR DESCRIPTION
##Description
This PR fixes a spelling error in the `interop-matrix.md` document. The project listed as "Kubematic" has been corrected to its proper name, "Kubermatic". 
Closes  #2310.
## How to use
N/A - This is a documentation fix.
## Testing done
- Verified that `github.com/kubermatic` exists and `github.com/kubematic` returns a 404 Not Found error.
- Verified the typo on line 71 of `interop-matrix.md` was successfully corrected.
