### PR TITLE
ci: improve workflow step names for clarity

### DIFF
--- a/.github/workflows/issue-pr-contrib-metrics.yaml
+++ b/.github/workflows/issue-pr-contrib-metrics.yaml
@@ -65,7 +65,7 @@ jobs:
             SEARCH_QUERY: 'repo:flatcar/Flatcar type:discussions category:Q&A is:unanswered'
             # This metric measures items that are still open
             HIDE_TIME_TO_CLOSE: true
-      - name: rename open discussion metrics file
+      - name: rename open Q&A discussion metrics file
         shell: bash
         run: |
           set -euo pipefail
@@ -76,7 +76,7 @@ jobs:
         env:
             GH_TOKEN: ${{ secrets.GH_ACTION_METRICS_ORG_READ }}
             SEARCH_QUERY: 'repo:flatcar/Flatcar type:discussions category:Q&A is:answered'
-      - name: rename open discussion metrics file
+      - name: rename closed Q&A discussion metrics file
         shell: bash
         run: |
           set -euo pipefail
@@ -87,7 +87,7 @@ jobs:
         env:
             GH_TOKEN: ${{ secrets.GH_ACTION_METRICS_ORG_READ }}
             SEARCH_QUERY: 'repo:flatcar/Flatcar type:discussions category:Q&A created:${{ env.START_DATE }}..${{ env.END_DATE }}'
-      - name: rename open discussion metrics file
+      - name: rename new Q&A discussion metrics file
         shell: bash
         run: |
           set -euo pipefail
@@ -114,7 +114,7 @@ jobs:
         env:
             GH_TOKEN: ${{ secrets.GH_ACTION_METRICS_ORG_READ }}
             SEARCH_QUERY: 'repo:flatcar/Flatcar type:discussions -category:Q&A created:${{ env.START_DATE }}..${{ env.END_DATE }}'
-      - name: rename open discussion metrics file
+      - name: rename new discussion metrics file
         shell: bash
         run: |
           set -euo pipefail
@@ -125,7 +125,7 @@ jobs:
         env:
             GH_TOKEN: ${{ secrets.GH_ACTION_METRICS_ORG_READ }}
             SEARCH_QUERY: 'repo:flatcar/Flatcar type:discussions -category:Q&A closed:${{ env.START_DATE }}..${{ env.END_DATE }}'
-      - name: rename open discussion metrics file
+      - name: rename closed discussion metrics file
         shell: bash
         run: |
           set -euo pipefail


### PR DESCRIPTION
## Summary
This PR improves the clarity of GitHub Actions logs by updating duplicated step names in the metrics workflow.

## Problem
Multiple steps currently use the same name ("rename open discussion metrics file") despite performing different operations.

## Changes
- Updated step names to reflect the actual file being renamed

## Why
- Makes workflow logs easier to read
- Simplifies debugging when a specific step fails

No functional changes were made.