### PR TITLE
Publish Security Insights, run Scorecard and enable Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,19 @@
+## Reference: https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+version: 2
+updates:
+  # This repository holds no source code, so the workflow actions are the only
+  # dependencies it has. They are pinned by commit SHA, which means nothing
+  # updates them unless something asks it to.
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    groups:
+      github-actions-dependencies:
+        patterns:
+          - "*"
+    commit-message:
+      prefix: ".github"
+    labels:
+      - "area/github-actions"

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,58 @@
+name: Scorecard analysis workflow
+on:
+  push:
+    # Only the default branch is supported.
+    branches:
+    - main
+  schedule:
+    # Daily
+    - cron: '30 1 * * *'
+
+# based on https://github.com/ossf/scorecard/blob/main/.github/workflows/scorecard-analysis.yml
+
+permissions: read-all
+
+jobs:
+  analysis:
+    name: Scorecard analysis
+    runs-on: ubuntu-latest
+    permissions:
+      # Needed for Code scanning upload
+      security-events: write
+      # Needed for GitHub OIDC token if publish_results is true
+      id-token: write
+
+    steps:
+      - name: "Checkout code"
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: "Run analysis"
+        uses: ossf/scorecard-action@2d1146689b8cda280b9bc96326124645441f03bc # v2.4.4
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          # Scorecard team runs a weekly scan of public GitHub repos,
+          # see https://github.com/ossf/scorecard#public-data.
+          # Setting `publish_results: true` helps us scale by leveraging your workflow to
+          # extract the results instead of relying on our own infrastructure to run scans.
+          # And it's free for you!
+          publish_results: true
+
+      # Upload the results as artifacts (optional). Commenting out will disable
+      # uploads of run results in SARIF format to the repository Actions tab.
+      # https://docs.github.com/en/actions/advanced-guides/storing-workflow-data-as-artifacts
+      - name: "Upload artifact"
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: SARIF file
+          path: results.sarif
+          retention-days: 5
+
+      # Upload the results to GitHub's code scanning dashboard (optional).
+      # Commenting out will disable upload of results to your repo's Code Scanning dashboard
+      - name: "Upload to code-scanning"
+        uses: github/codeql-action/upload-sarif@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6
+        with:
+          sarif_file: results.sarif

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 [![Mastodon Follow](https://img.shields.io/badge/Mastodon-Follow-6364FF?logo=mastodon)](https://hachyderm.io/@flatcar)
 [![Bluesky](https://img.shields.io/badge/Bluesky-Follow-0285FF?logo=bluesky)](https://bsky.app/profile/flatcar.org)
 [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/10926/badge)](https://www.bestpractices.dev/projects/10926)
+[![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/flatcar/Flatcar/badge)](https://scorecard.dev/viewer/?uri=github.com/flatcar/Flatcar)
 
 
 > **Note:** To file an issue for any Flatcar repository, please use the [central Flatcar issue tracker](https://github.com/flatcar/Flatcar/issues).

--- a/SECURITY-INSIGHTS.yml
+++ b/SECURITY-INSIGHTS.yml
@@ -1,0 +1,174 @@
+## OpenSSF Security Insights manifest for the Flatcar project.
+## Specification: https://github.com/ossf/security-insights-spec
+header:
+  schema-version: 2.2.0
+  last-updated: '2026-08-11'
+  last-reviewed: '2026-08-11'
+  url: https://raw.githubusercontent.com/flatcar/Flatcar/main/SECURITY-INSIGHTS.yml
+  comment: |
+    This repository is the central issue tracker and the home of the project
+    documentation for the whole flatcar GitHub organisation. It carries no source
+    code; the OS itself is built in flatcar/scripts.
+
+    MAINTAINERS.md is the authoritative list of maintainers and of the security
+    team. The contacts below are a snapshot of it and are refreshed whenever this
+    file is reviewed.
+
+project:
+  name: Flatcar Container Linux
+  homepage: https://www.flatcar.org/
+  roadmap: https://github.com/orgs/flatcar/projects/7/views/9
+  steward:
+    uri: https://www.cncf.io/
+    comment: |
+      Flatcar Container Linux was accepted into the CNCF at the incubating
+      maturity level in August 2024.
+  administrators:
+    - name: Thilo Fromm
+      affiliation: Microsoft
+      social: https://github.com/t-lo
+      primary: true
+  documentation:
+    quickstart-guide: https://www.flatcar.org/docs/latest/installing/
+    detailed-guide: https://www.flatcar.org/docs/latest/
+    code-of-conduct: https://github.com/flatcar/Flatcar/blob/main/CODE_OF_CONDUCT.md
+    release-process: https://www.flatcar.org/docs/latest/reference/developer-guides/release-guide/
+    support-policy: https://github.com/flatcar/Flatcar/blob/main/RELEASES.md
+  repositories:
+    - name: Flatcar
+      url: https://github.com/flatcar/Flatcar
+      comment: |
+        This repository. Central issue tracker for the organisation, plus project
+        documentation, governance and release planning.
+    - name: scripts
+      url: https://github.com/flatcar/scripts
+      comment: |
+        The image build system, the SDK and the package definitions. Most
+        OS-level changes land here, and the release images are built from it.
+    - name: mantle
+      url: https://github.com/flatcar/mantle
+      comment: |
+        The kola test framework, the image upload tooling and assorted build glue.
+    - name: update_engine
+      url: https://github.com/flatcar/update_engine
+      comment: |
+        The Omaha update client that runs on every node and drives the atomic
+        A/B partition updates.
+    - name: nebraska
+      url: https://github.com/flatcar/nebraska
+      comment: |
+        The Omaha update server used to manage and roll out updates to fleets.
+    - name: ignition
+      url: https://github.com/flatcar/ignition
+      comment: |
+        Flatcar's fork of Ignition, the first-boot provisioning tool.
+    - name: bootengine
+      url: https://github.com/flatcar/bootengine
+      comment: |
+        The dracut-based initramfs that prepares the root filesystem at boot.
+    - name: sysext-bakery
+      url: https://github.com/flatcar/sysext-bakery
+      comment: |
+        Recipes for building systemd-sysext images that layer software onto the
+        read-only OS.
+    - name: flatcar-website
+      url: https://github.com/flatcar/flatcar-website
+      comment: |
+        Source for flatcar.org, including the user and developer documentation.
+  vulnerability-reporting:
+    reports-accepted: true
+    bug-bounty-available: false
+    contact:
+      name: Flatcar security team
+      email: security@flatcar-linux.org
+      primary: true
+    policy: https://github.com/flatcar/Flatcar/blob/main/SECURITY.md
+    comment: |
+      Undisclosed issues are tracked in a private repository that only the
+      security team can read. Issues that are already public are tracked in this
+      repository under the security and advisory labels. Fixes ship as an updated
+      OS image, and every release carries a report on the issues it addresses.
+
+repository:
+  url: https://github.com/flatcar/Flatcar
+  status: active
+  accepts-change-request: true
+  accepts-automated-change-request: true
+  core-team:
+    - name: Thilo Fromm
+      primary: true
+    - name: James Le Cuirot
+      primary: false
+    - name: Krzesimir Nowak
+      primary: false
+    - name: Sayan Chowdhury
+      primary: false
+    - name: Gabriel Samfira
+      primary: false
+    - name: Kai Lüke
+      primary: false
+    - name: Adrian Vladu
+      primary: false
+    - name: Daniel Zatovic
+      primary: false
+    - name: Jeremi Piotrowski
+      primary: false
+    - name: Dongsu Park
+      primary: false
+    - name: Danielle Tal
+      primary: false
+    - name: Mathieu Tortuyaux
+      primary: false
+    - name: Ervin Racz
+      primary: false
+    - name: Jan Bronicki
+      primary: false
+    - name: Lexi Nadolski
+      primary: false
+    - name: Robin Schneider
+      primary: false
+  license:
+    url: https://github.com/flatcar/Flatcar/blob/main/LICENSE
+    expression: Apache-2.0
+  documentation:
+    contributing-guide: https://github.com/flatcar/Flatcar/blob/main/CONTRIBUTING.md
+    governance: https://github.com/flatcar/Flatcar/blob/main/governance.md
+    review-policy: https://github.com/flatcar/Flatcar/blob/main/CONTRIBUTING.md#pull-request-lifecycle
+    security-policy: https://github.com/flatcar/Flatcar/blob/main/SECURITY.md
+    dependency-management-policy: https://github.com/flatcar/Flatcar/blob/main/adding-new-packages.md
+  security:
+    assessments:
+      self:
+        comment: |
+          The security self assessment required for CNCF graduation is still in
+          progress and is tracked in
+          https://github.com/flatcar/Flatcar/issues/1820. This entry will be
+          updated with a link to the published assessment once it is finished.
+    tools:
+      - name: Dependabot
+        type: SCA
+        rulesets:
+          - default
+        integration:
+          adhoc: true
+          ci: false
+          release: false
+        results: {}
+        comment: |
+          Runs weekly against the GitHub Actions used by the workflows in this
+          repository and opens a pull request per update. See
+          https://github.com/flatcar/Flatcar/blob/main/.github/dependabot.yml.
+      - name: OpenSSF Scorecard
+        type: other
+        rulesets:
+          - default
+        integration:
+          adhoc: true
+          ci: false
+          release: false
+        results: {}
+        comment: |
+          Runs daily and on every push to the default branch. Results are
+          published to the Scorecard API and uploaded to the repository code
+          scanning dashboard. See
+          https://github.com/flatcar/Flatcar/blob/main/.github/workflows/scorecard.yml.


### PR DESCRIPTION
# Publish a Security Insights manifest, run OpenSSF Scorecard and enable Dependabot

Our CLOMonitor report at [https://clomonitor.io/projects/cncf/flatcar](https://clomonitor.io/projects/cncf/flatcar) is part of the evidence the CNCF looks at for graduation (#1818). It currently fails four checks that this repository can fix on its own: `security_insights`, `dependencies_policy`, `dependency_update_tool` and `openssf_scorecard_badge`.

This adds `SECURITY-INSIGHTS.yml` on spec v2.2.0, a Dependabot config for the `github-actions` ecosystem, the Scorecard analysis workflow, and a Scorecard badge in the README. The manifest fixes two checks at once, because CLOMonitor reads `dependencies_policy` from `repository.documentation.dependency-management-policy` in the same file. Everything in the manifest comes from documents already in this repo, from `MAINTAINERS.md`, and from the CNCF project maintainers list. The self assessment entry points at #1820 rather than claiming an assessment we have not published. The workflow and the Dependabot config are the ones already running in `flatcar/nebraska`, with the pinned action SHAs refreshed.

I reimplemented the CLOMonitor scoring from its source and confirmed it reproduces our current published numbers exactly (repo 75.00, project 80.17). On that basis this moves security from 63.64 to 86.36, best practices from 52.63 to 78.95, and the project global from 80.17 to 88.43.

Fixes #2317 

## How to use

Nothing to do on a running system. To validate the manifest against the specification's own schema:

```
git clone --depth 1 https://github.com/ossf/security-insights-spec.git
cd security-insights-spec
cue vet -c -d '#SecurityInsights' ./spec /path/to/Flatcar/SECURITY-INSIGHTS.yml
```

After merge, the Scorecard workflow runs on the push to `main` and again daily at 01:30 UTC. CLOMonitor refreshes roughly once a day, so the four checks should flip on the project page within about 24 hours.

## Testing done

Validated the manifest against the spec schema, with the spec's own example as a control so a silent pass is ruled out:

```
$ cue vet -c -d '#SecurityInsights' ./spec examples/example-full.yml
$ echo $?
0
$ cue vet -c -d '#SecurityInsights' ./spec SECURITY-INSIGHTS.yml
$ echo $?
0
```

Linted both workflows:

```
$ actionlint .github/workflows/*.yml .github/workflows/*.yaml
$ echo $?
0
```

Checked every URL in the manifest. All 29 return 200, apart from three that point at files this PR adds and which resolve once it lands.

Simulated the four CLOMonitor checks against the branch, using the path order and regexes from `clomonitor-core/src/linter/checks`:

```
security_insights          : PASS   (manifest=SECURITY-INSIGHTS.yml, schema=v2)
dependencies_policy        : PASS   (.../adding-new-packages.md)
openssf_scorecard_badge    : PASS   (https://api.scorecard.dev/projects/github.com/flatcar/Flatcar)
dependency_update_tool     : PASS
```

- [ ] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
- [ ] Inspected CI output for image differences: `/boot` and `/usr` size, packages, list files for any missing binaries, kernel modules, config files, kernel modules, etc.

Both boxes are left unchecked on purpose. This repository has no `changelog/` directory and builds no image, so neither applies here.