### PR TITLE
docs: fix "GiantSwarm" to "Giant Swarm" in interop-matrix.md

### DIFF
--- a/interop-matrix.md
+++ b/interop-matrix.md
@@ -41,7 +41,7 @@ Please propose ownership by filing a PR for this document.
 | Environment | Full-Feature (release blocker) | Works | Tested (CI) | Owner | Reference (e.g. GH issue) | Notes |
 |-------------|--------------------------------|-------|-------------|-------|---------------------------|-------|
 | EKS         |                                |   X   |             | [no owner] |                      |       |
-| GiantSwarm  |                                |   X   |             | Provider |                        |       |
+| Giant Swarm |                                |   X   |             | Provider |                        |       |
 
 ## Cluster API
 


### PR DESCRIPTION
## Title

docs: fix "GiantSwarm" to "Giant Swarm" in interop-matrix.md

## Body

Giant Swarm GmbH's actual name is two words, per their own site ([giantswarm.io](https://www.giantswarm.io/)) and this repo's own `ADOPTERS.md`, which already spells it correctly ("Giant Swarm uses Flatcar within their Kubernetes Distribution...").

Small, mechanical, single-row fix in the same table/style as the recently merged #2267 and #2311.
