### PR TITLE
docs: fix "Tanzu KG" to "Tanzu Kubernetes Grid (TKG)" in interop-matrix.md

### DIFF
--- a/interop-matrix.md
+++ b/interop-matrix.md
@@ -63,7 +63,7 @@ Please propose ownership by filing a PR for this document.
 | AKS Engine  |                                |   X   |             | [no owner] |                      | https://kinvolk.io/blog/2020/12/aks-engine-on-flatcar |
 | Rancher (rke) |                              |   X   |             | [no owner] |                      |       |
 | Rancher (rke2) |                             |       |             | [no owner] |                      |       |
-| Tanzu KG |                                   |   X   |             | [no owner] |                      |       |
+| Tanzu Kubernetes Grid (TKG) |                   |   X   |             | [no owner] |                      |       |
 | K3s |                                        |   X   |             | [no owner] |                      |       |
 | EKS-Distro |                                 |   X   |             | [no owner] |                      |       |
 | KOPS |                                       |   X   |             | upstream |                        |       |


### PR DESCRIPTION



## Body

VMware's product is "Tanzu Kubernetes Grid", officially abbreviated **TKG** - confirmed via [Broadcom's Tanzu documentation](https://techdocs.broadcom.com/us/en/vmware-tanzu/standalone-components/tanzu-kubernetes-grid/2-5/tkg/about-tkg-index.html). "Tanzu KG" isn't a real product name or abbreviation.

Small, mechanical, single-row fix in the same table/style as the recently merged #2267
